### PR TITLE
Register MyObject class to PythonQt in VariantConvert.addVariableObject unittest

### DIFF
--- a/tests/unittests/test_variantconvert.cpp
+++ b/tests/unittests/test_variantconvert.cpp
@@ -79,6 +79,10 @@ TEST(VariantConvert, addVariableObject)
     o.setObjectName("Object3");
     ctxMgr->addVariable(context.id(), "obj3", QVariant::fromValue(&o));
 
+    // register the class so PythonQt can convert the Python object to a
+    // QVariant in PythonQtConv::PyObjToQVariant()
+    PythonQt::self()->registerClass(o.metaObject());
+
     // get back the object from python
     auto objPtr = ctxMgr->getVariable(context.id(), "obj3").value<GtObject*>();
     ASSERT_TRUE(objPtr != nullptr);


### PR DESCRIPTION
`GtpyContextManager::addGtObject()` automatically registers the meta-object of the passed `GtObject` to PythonQt. That's why the unittests do not fail when executing VariantConvert.addGtObject before VariantConvert.addVariableObject. However, when executing only VariantConvert.addVariableObject, the `MyObject` class is not registered to PythonQt. So the object cannot be converted to a `QVariant`.