### PR TITLE
Added support for an embedded python environment

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -103,7 +103,7 @@ testWin_2.0:
 testLinux_2.0:
   stage: test_2.0
   tags: ["linux", "docker"]
-  image: at-twk-hal9000.intra.dlr.de:5000/dlr-at/gtlabdev-2_0-buster
+  image: at-twk-hal9000.intra.dlr.de:5000/dlr-at/gtlabdev-2_0-buster:2.0.14
   needs: ["linuxBuildDebug_2.0"]
   before_script:
     # update to latest dev tools
@@ -123,7 +123,7 @@ testLinux_2.0:
 code-coverage:
   stage: codequality
   tags: ["linux", "docker"]
-  image: at-twk-hal9000.intra.dlr.de:5000/dlr-at/gtlabdev-2_0-buster
+  image: at-twk-hal9000.intra.dlr.de:5000/dlr-at/gtlabdev-2_0-buster:2.0.14
   extends: 
     - .build-linux_20
   script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Fixed the automated code generation for double and bool properties in the Python Task wizard - #279
 
 ### Added
+ - Support for an embedded python distribution, that comes along with GTlab - #585
  - String input values for Python Tasks and Python Calculators now allow special characters - #269
 
 ## [1.6.1] - 2024-11-08


### PR DESCRIPTION
This PR should allow to ship a python distribution with GTlab in lib/python. 

If so, the setup module will find it and adjust the interpreter to use it if not otherwise set.