### PR TITLE
Fixed error, when a subprocess tries to redirect stdout messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+ - Fixed an error, when a subprocess tries to redirect messages to the GTlab console.
+   The missing fileno() method of has been implemented.
+   Note: the redirection using a file handle is not properly supported!
+   Instead, the messages will be printed to a system terminal - #277
+
 ## [1.7.0] - 2025-04-07
 
 ### Fixed

--- a/src/module/utilities/gtpy_contextmanager.cpp
+++ b/src/module/utilities/gtpy_contextmanager.cpp
@@ -2033,3 +2033,9 @@ GtpyTypeConversion::convertToQMapStringQString(PyObject *obj, void *outMap,
 {
     return pythonToMap<QString, QString>(obj, outMap);
 }
+
+GtpyContextManager&
+gtpyContextManager()
+{
+    return *GtpyContextManager::instance();
+}

--- a/src/module/utilities/gtpy_contextmanager.h
+++ b/src/module/utilities/gtpy_contextmanager.h
@@ -644,6 +644,12 @@ signals:
 
 };
 
+/**
+ * @brief Returns the context manager instance
+ */
+GT_PYTHON_EXPORT GtpyContextManager& gtpyContextManager();
+
+
 Q_DECLARE_METATYPE(GtpyContextManager::Context);
 
 /**


### PR DESCRIPTION
Fixed an error, when a subprocess tries to redirect messages to the GTlab console.
The missing fileno() method of has been implemented.

__Note__: the redirection using a file handle is not properly supported!  Instead, the messages will be printed to a system terminal, since we are not using a file handle internally to pipe to gtlab's console

Fixes #277