### PR TITLE
Support more usual syntax for gtinfo etc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Fixed python editor silently discard changes, when it is closed.
    Now, the user is asked whether to store these changes or not. - #592
 
+### Added
+ - Log messages in Python by passing an argument to the logging functions (e.g. gtDebug('debug message'), gtInfo('info message'), etc.). Logging via the lshift operator is still supported but is no longer recommended (e.g., gtDebug() << 'debug message'). - #595
+
 ## [1.7.0] - 2025-04-07
 
 ### Fixed

--- a/src/module/utilities/gtpypp.h
+++ b/src/module/utilities/gtpypp.h
@@ -301,6 +301,11 @@ inline PyPPObject PyPPObject_Repr(const PyPPObject& o)
     return PyPPObject::NewRef(PyObject_Repr(o.get()));
 }
 
+inline PyPPObject PyPPObject_Str(const PyPPObject& obj)
+{
+    return PyPPObject::NewRef(PyObject_Str(obj.get()));
+}
+
 inline PyPPObject PyPPObject_GenericGetAttr(const PyPPObject& o, const PyPPObject& name)
 {
     return PyPPObject::NewRef(PyObject_GenericGetAttr(o.get(), name.get()));
@@ -362,13 +367,7 @@ inline QString PyPPString_AsQString(const PyPPObject& obj)
 
 inline QString PyPPObject_AsQString(const PyPPObject& obj)
 {
-    auto strObj = obj;
-
-    if (!PyPPUnicode_Check(strObj))
-   {
-        strObj =  PyPPObject::NewRef(PyObject_Str(obj.get()));
-   }
-
+   auto strObj = PyPPUnicode_Check(obj) ? obj : PyPPObject_Str(obj);
    return PyPPString_AsQString(strObj);
 }
 

--- a/src/module/utilities/pythonextensions/gtpy_loggingmodule.cpp
+++ b/src/module/utilities/pythonextensions/gtpy_loggingmodule.cpp
@@ -19,7 +19,7 @@ using namespace GtpyLoggingModule;
 namespace
 {
 
-bool isLoggingEnabled()
+bool isLoggingToAppConsolEnabled()
 {
     auto globals = PyPPEval_GetGlobals();
     if (!globals || !PyPPDict_Check(globals)) return false;
@@ -62,7 +62,7 @@ void printToPyConsol(LogLevel type, const QString& msg)
 
 void printToAppConsol(LogLevel type, const QString& msg)
 {
-    if (!isLoggingEnabled()) return;
+    if (!isLoggingToAppConsolEnabled()) return;
 
     switch (type)
     {

--- a/src/module/utilities/pythonextensions/gtpy_loggingmodule.h
+++ b/src/module/utilities/pythonextensions/gtpy_loggingmodule.h
@@ -14,16 +14,14 @@
 #include <QString>
 
 #include "PythonQtPythonInclude.h"
-#include "structmember.h"
-
-#include "gt_task.h"
 
 #include "gtpy_globals.h"
+#include "gtpy_code.h"
 
 namespace GtpyLoggingModule
 {
 
-enum OutputType
+enum LogLevel
 {
     DEBUG = 0,
     INFO,
@@ -37,51 +35,71 @@ extern PyTypeObject GtpyPyLogger_Type;
 typedef struct
 {
     PyObject_HEAD
-    PyObject* m_outputType;
+    PyObject* m_logLevel;
 } GtpyPyLogger;
 
 extern PyObjectAPIReturn
-gtDebug_C_function();
+gtDebug_C_function(PyObject* self, PyObject* args);
 
 extern PyObjectAPIReturn
-gtInfo_C_function();
+gtInfo_C_function(PyObject* self, PyObject* args);
 
 extern PyObjectAPIReturn
-gtError_C_function();
+gtError_C_function(PyObject* self, PyObject* args);
 
 extern PyObjectAPIReturn
-gtFatal_C_function();
+gtFatal_C_function(PyObject* self, PyObject* args);
 
 extern PyObjectAPIReturn
-gtWarning_C_function();
+gtWarning_C_function(PyObject* self, PyObject* args);
 
 static PyMethodDef
 GtpyLoggingModule_StaticMethods[] =
 {
     {
-        "gtDebug", (PyCFunction)gtDebug_C_function, METH_NOARGS,
-        "GtpyPyLogger gtDebug() --> Returns a GtpyPyLogger instance that "
-        "enables debug outputs"
+        gtpy::code::funcs::GT_DEBUG, (PyCFunction)gtDebug_C_function,
+        METH_VARARGS,
+        "gtDebug([message]) -> None | GtpyPyLogger\n"
+        "Logs a debug-level message if a message is provided.\n"
+        "Otherwise returns a GtpyPyLogger instance that allows logging using "
+        "the lshift operator (e.g. gtDebug() << 'debug message').\n"
+        "The recommended usage is: gtDebug('debug message')."
     },
     {
-        "gtInfo", (PyCFunction)gtInfo_C_function, METH_NOARGS,
-        "GtpyPyLogger gtInfo() --> Returns a GtpyPyLogger instance that "
-        "enables info outputs"
+        gtpy::code::funcs::GT_INFO, (PyCFunction)gtInfo_C_function,
+        METH_VARARGS,
+        "gtInfo([message]) -> None | GtpyPyLogger\n"
+        "Logs an info-level message if a message is provided.\n"
+        "Otherwise returns a GtpyPyLogger instance that allows logging using "
+        "the lshift operator (e.g. gtInfo() << 'info message').\n"
+        "The recommended usage is: gtInfo('info message')."
     },
     {
-        "gtError", (PyCFunction)gtError_C_function, METH_NOARGS,
-        "GtpyPyLogger gtError() --> Returns a GtpyPyLogger instance that "
-        "enables error outputs"
+        gtpy::code::funcs::GT_ERROR, (PyCFunction)gtError_C_function,
+        METH_VARARGS,
+        "gtError([message]) -> None | GtpyPyLogger\n"
+        "Logs an error-level message if a message is provided.\n"
+        "Otherwise returns a GtpyPyLogger instance that allows logging using "
+        "the lshift operator (e.g. gtError() << 'error message').\n"
+        "The recommended usage is: gtError('error message')."
     },
     {
-        "gtFatal", (PyCFunction)gtFatal_C_function, METH_NOARGS,
-        "GtpyPyLogger gtFatal() --> Returns a GtpyPyLogger instance that "
-        "enables fatal outputs"
+        gtpy::code::funcs::GT_FATAL, (PyCFunction)gtFatal_C_function,
+        METH_VARARGS,
+        "gtFatal([message]) -> None | GtpyPyLogger\n"
+        "Logs a fatal-level message if a message is provided.\n"
+        "Otherwise returns a GtpyPyLogger instance that allows logging using "
+        "the lshift operator (e.g. gtFatal() << 'fatal message').\n"
+        "The recommended usage is: gtFatal('fatal message')."
     },
     {
-        "gtWarning", (PyCFunction)gtWarning_C_function, METH_NOARGS,
-        "GtpyPyLogger gtWarning() --> Returns a GtpyPyLogger instance that "
-        "enables warning outputs"
+        gtpy::code::funcs::GT_WARNING, (PyCFunction)gtWarning_C_function,
+        METH_VARARGS,
+        "gtWarning([message]) -> None | GtpyPyLogger\n"
+        "Logs a warning-level message if a message is provided.\n"
+        "Otherwise returns a GtpyPyLogger instance that allows logging using "
+        "the lshift operator (e.g. gtWarning() << 'warning message').\n"
+        "The recommended usage is: gtWarning('warning message')."
     },
     { NULL, NULL, 0, NULL }
 };


### PR DESCRIPTION
This PR enables logging of messages in Python by passing an argument to the logging functions (e.g. `gtDebug('debug message')`, `gtInfo('info message')`, ...). Logging via the lshift operator is still supported. 

Now, the logging functions check if an argument is passed. If an argument is passed, it will be converted to a string and logged. If no argument is passed, a GtpyPyLogger instance is returned, allowing logging via the lshift operator (e.g., `gtDebug() << 'debug message')`).