### PR TITLE
Store wizard geometry instead of frame geometry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+ - The Python Task and Calculator wizard no longer increases in height each time it is reopened. - #607
+
 ## [1.7.1] - 2025-04-23
 
 ### Fixed

--- a/src/module/wizards/gtpy_abstractscriptingwizardpage.cpp
+++ b/src/module/wizards/gtpy_abstractscriptingwizardpage.cpp
@@ -842,7 +842,7 @@ GtpyAbstractScriptingWizardPage::registerGeometry()
         if (wiz)
         {
 
-            QRect rect = wiz->frameGeometry();
+            QRect rect = wiz->geometry();
 
             GtpyWizardGeometries::instance()->registerGeometry(m_componentUuid,
                     rect);


### PR DESCRIPTION
The issue was caused by using `QWidget::frameGeometry()` to save the wizard size. `QWidget::frameGeometry()` includes the title bar. On reopening we restore the geometry of the widget excluding the title bar. This mismatch causes the increasing height.

Switching to `QWidget::geometry()` fixes the bug.