### PR TITLE
Enable access to Python Context and dynamic function adding

### DIFF
--- a/src/module/utilities/gtpy_context.h
+++ b/src/module/utilities/gtpy_context.h
@@ -13,7 +13,8 @@
 
 #include <QString>
 
-#include "gtpy_module.h"
+#include <gtpy_module.h>
+#include <gt_pythonmodule_exports.h>
 
 /**
  * @brief The GtpyContext class represents a C++ interface for a Python module
@@ -24,7 +25,7 @@
  * or executing tasks and calculators. The functionality provided by the context
  * depends on the ContextType passed to the constructor.
  */
-class GtpyContext : public GtpyModule
+class GT_PYTHON_EXPORT GtpyContext : public GtpyModule
 {
     // The friend relationship allows to integrate GtpyContext into the
     // GtpyContextManager without modifying its API. It will probably be

--- a/src/module/utilities/gtpy_contextmanager.cpp
+++ b/src/module/utilities/gtpy_contextmanager.cpp
@@ -859,10 +859,10 @@ GtpyContextManager::createCustomModule(
     return !PythonQt::self()->hadError();
 }
 
-std::shared_ptr<GtpyContext>
+GtpyContext*
 GtpyContextManager::context(int contextId) const
 {
-    return m_contextMap.value(contextId, nullptr);
+    return m_contextMap.value(contextId, nullptr).get();
 }
 
 #ifdef PY3K

--- a/src/module/utilities/gtpy_contextmanager.h
+++ b/src/module/utilities/gtpy_contextmanager.h
@@ -324,6 +324,13 @@ public:
      */
     bool initMatplotlib();
 
+    /**
+    * @brief Returns a pointer to the Python context indicated by contextId.
+    * @param contextId Python context identifier.
+    * @return Pointer to Python Context, nullptr if contextid is invalid
+    */
+    GtpyContext* context(int contextId) const;
+
 protected:
     /**
     * @brief The GtpyContextManager constructor.
@@ -356,12 +363,6 @@ private:
      */
     bool createCustomModule(const QString& moduleName, const QString& code);
 
-    /**
-    * @brief Returns a pointer to the Python context indicated by contextId.
-    * @param contextId Python context identifier.
-    * @return Pointer to Python Context.
-    */
-    std::shared_ptr<GtpyContext> context(int contextId) const;
 
 #ifdef PY3K
     /**

--- a/src/module/utilities/gtpy_module.h
+++ b/src/module/utilities/gtpy_module.h
@@ -16,15 +16,17 @@
 #include <QString>
 #include <QObject>
 
-#include "PythonQtPythonInclude.h"
+#include <PythonQtPythonInclude.h>
 
-#include "gtpypp.h"
+#include <gtpypp.h>
+
+#include <gt_pythonmodule_exports.h>
 
 /**
  * @brief The GtpyModule class represents a C++ interface for a Python module.
  * A Python module corresponds to an importable *.py file.
  */
-class GtpyModule
+class GT_PYTHON_EXPORT GtpyModule
 {
 public:
     /**
@@ -100,7 +102,6 @@ public:
      */
     const QString& moduleName() const;
 
-protected:
     /**
      * @brief Adds a set of functions defined by the provided PyMethodDef
      * array to the Python module associated with this instance. The functions
@@ -112,6 +113,8 @@ protected:
      * @return True if the functions were successfully added, otherwise false.
      */
     bool addFunctions(PyMethodDef* def);
+
+protected:
 
     /**
      * @brief Returns the Python module object that is associated with the


### PR DESCRIPTION
Note: I changed the return type of GtpyContextManager::context to raw pointers, to disable the transfer of ownership. Imho, the Context Manager should be the only owner of a context. This should not affect the use of the function though.

Fixed #610