### PR TITLE
Use map container properties for process elements

### DIFF
--- a/src/module/CMakeLists.txt
+++ b/src/module/CMakeLists.txt
@@ -90,6 +90,7 @@ set(HEADERS
     wizards/gtpy_wizardgeometryitem.h
     wizards/python_task/gtpy_taskwizardpage.h
     wizards/script_calculator/gtpy_scriptcalculatorwizardpage.h
+    utilities/gtpy_moduleupgrader.h
 )
 
 set(SOURCES
@@ -162,6 +163,7 @@ set(SOURCES
     wizards/gtpy_wizardgeometryitem.cpp
     wizards/python_task/gtpy_taskwizardpage.cpp
     wizards/script_calculator/gtpy_scriptcalculatorwizardpage.cpp
+    utilities/gtpy_moduleupgrader.cpp
 )
 
 set(MODULE_ID "Python Module (Python ${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR})")

--- a/src/module/gt_python.cpp
+++ b/src/module/gt_python.cpp
@@ -55,8 +55,10 @@
 #include "gt_accessdataconnection.h"
 
 #include "gtpy_scriptcollectionsettings.h"
+#include "gtpy_moduleupgrader.h"
 
 #include "gt_python.h"
+
 
 #if GT_VERSION >= 0x010700
 GtVersionNumber
@@ -327,6 +329,19 @@ QList<gt::SharedFunction> GtPythonModule::sharedFunctions() const
 }
 #endif
 
+QList<gt::VersionUpgradeRoutine>
+GtPythonModule::upgradeRoutines() const
+{
+    return
+        {
+#if GT_VERSION >= GT_VERSION_CHECK(2, 1, 0)
+            gt::VersionUpgradeRoutine {GtVersionNumber(2, 0, 0),
+                                       &gtpy::module_upgrader::to_2_0_0::run}
+#endif
+        };
+}
+
+
 namespace PythonExecution
 {
 
@@ -349,6 +364,7 @@ parseScriptFile(QFile& file)
 
     return out.readAll();
 }
+
 
 int
 runPythonInterpreter(const QStringList& args)

--- a/src/module/gt_python.cpp
+++ b/src/module/gt_python.cpp
@@ -332,20 +332,12 @@ QList<gt::SharedFunction> GtPythonModule::sharedFunctions() const
 QList<gt::VersionUpgradeRoutine>
 GtPythonModule::upgradeRoutines() const
 {
-    GtVersionNumber current = const_cast<GtPythonModule*>(this)->version();
-
-    if(current >= GtVersionNumber(2, 0, 0))
-    {
-        return
-            {
+    return {
 #if GT_VERSION >= GT_VERSION_CHECK(2, 1, 0)
                 gt::VersionUpgradeRoutine {GtVersionNumber(2, 0, 0),
                                           &gtpy::module_upgrader::to_2_0_0::run}
 #endif
-            };
-    }
-
-    return {};
+    };
 }
 
 

--- a/src/module/gt_python.cpp
+++ b/src/module/gt_python.cpp
@@ -332,13 +332,20 @@ QList<gt::SharedFunction> GtPythonModule::sharedFunctions() const
 QList<gt::VersionUpgradeRoutine>
 GtPythonModule::upgradeRoutines() const
 {
-    return
-        {
+    GtVersionNumber current = const_cast<GtPythonModule*>(this)->version();
+
+    if(current >= GtVersionNumber(2, 0, 0))
+    {
+        return
+            {
 #if GT_VERSION >= GT_VERSION_CHECK(2, 1, 0)
-            gt::VersionUpgradeRoutine {GtVersionNumber(2, 0, 0),
-                                       &gtpy::module_upgrader::to_2_0_0::run}
+                gt::VersionUpgradeRoutine {GtVersionNumber(2, 0, 0),
+                                          &gtpy::module_upgrader::to_2_0_0::run}
 #endif
-        };
+            };
+    }
+
+    return {};
 }
 
 

--- a/src/module/gt_python.h
+++ b/src/module/gt_python.h
@@ -177,6 +177,9 @@ public:
     QList<GtCommandLineFunction> commandLineFunctions() const override;
 
     QList<gt::SharedFunction> sharedFunctions() const override;
+
+    /** We are providing routines to upgrade the datamodel */
+    QList<gt::VersionUpgradeRoutine> upgradeRoutines() const override;
 #endif
 
 private:

--- a/src/module/processcomponents/gtpy_abstractscriptcomponent.cpp
+++ b/src/module/processcomponents/gtpy_abstractscriptcomponent.cpp
@@ -41,13 +41,14 @@ setStructContainerValue(GtPropertyStructContainer& con, const QString& argName,
 {
     auto entry = std::find_if(con.begin(), con.end(),
                               [&argName](const GtPropertyStructInstance& entry){
+#if GT_VERSION >= GT_VERSION_CHECK(2, 1, 0)
+        return entry.ident() == argName;
+#elif GT_VERSION >= GT_VERSION_CHECK(2, 0, 0)
         return entry.getMemberVal<QString>("name") == argName;
+#endif
     });
 
-    if (entry == con.end())
-    {
-        return false;
-    }
+    if (entry == con.end()) return false;
 
     return entry->setMemberVal("value", value);
 }
@@ -57,13 +58,15 @@ structContainerValue(const GtPropertyStructContainer& con, const QString& argNam
 {
     auto entry = std::find_if(con.begin(), con.end(),
                               [&argName](const GtPropertyStructInstance& entry){
+#if GT_VERSION >= GT_VERSION_CHECK(2, 1, 0)
+        return entry.ident() == argName;
+#elif GT_VERSION >= GT_VERSION_CHECK(2, 0, 0)
         return entry.getMemberVal<QString>("name") == argName;
+#endif
+
     });
 
-    if (entry == con.end())
-    {
-        return {};
-    }
+    if (entry == con.end()) return {};
 
     return entry->getMemberValToVariant("value");
 }
@@ -93,7 +96,11 @@ GtpyAbstractScriptComponent::GtpyAbstractScriptComponent() :
     m_replaceTabBySpaces{"replaceTab", "Replace tab by spaces"},
     m_tabSize{"tabSize", "Tab size"},
     m_script{"script", "Script"}
-#if GT_VERSION >= GT_VERSION_CHECK(2, 0, 0)
+#if GT_VERSION >= GT_VERSION_CHECK(2, 1, 0)
+    ,
+    m_inputArgs{"input_args",  GtPropertyStructContainer::Associative},
+    m_outputArgs{"output_args",  GtPropertyStructContainer::Associative}
+#elif GT_VERSION >= GT_VERSION_CHECK(2, 0, 0)
     ,
     m_inputArgs{"input_args"},
     m_outputArgs{"output_args"}
@@ -104,7 +111,9 @@ GtpyAbstractScriptComponent::GtpyAbstractScriptComponent() :
     auto createStructDef =
             [](const QString& typeName, gt::PropertyFactoryFunction f){
         GtPropertyStructDefinition structDef(typeName);
+    #if GT_VERSION < GT_VERSION_CHECK(2, 1, 0)
         structDef.defineMember("name", gt::makeStringProperty());
+    #endif // GT_VERSION < GT_VERSION_CHECK(2, 1, 0)
         structDef.defineMember("value", f);
         return structDef;
     };

--- a/src/module/processcomponents/gtpy_abstractscriptcomponent.cpp
+++ b/src/module/processcomponents/gtpy_abstractscriptcomponent.cpp
@@ -95,13 +95,11 @@ GtpyAbstractScriptComponent::GtpyAbstractScriptComponent() :
     m_pyThreadId{-1},
     m_replaceTabBySpaces{"replaceTab", "Replace tab by spaces"},
     m_tabSize{"tabSize", "Tab size"},
-    m_script{"script", "Script"}
+    m_script{"script", "Script"},
 #if GT_VERSION >= GT_VERSION_CHECK(2, 1, 0)
-    ,
     m_inputArgs{"input_args",  GtPropertyStructContainer::Associative},
     m_outputArgs{"output_args",  GtPropertyStructContainer::Associative}
 #elif GT_VERSION >= GT_VERSION_CHECK(2, 0, 0)
-    ,
     m_inputArgs{"input_args"},
     m_outputArgs{"output_args"}
 #endif

--- a/src/module/utilities/gtpy_decorator.cpp
+++ b/src/module/utilities/gtpy_decorator.cpp
@@ -1053,14 +1053,11 @@ GtpyDecorator::getPropertyContainerVal(GtObject* obj,
         return {};
     }
 
-    for (int index = 0; index < s->size(); ++index)
-    {
-        if (s->at(index).ident() == entryId)
-        {
-            GtPropertyStructInstance& structCon = s->at(index);
+    GtPropertyStructContainer::const_iterator it = s->findEntry(entryId);
 
-            return structCon.getMemberValToVariant(memberId);
-        }
+    if (it != s->end())
+    {
+        return it->getMemberValToVariant(memberId);
     }
 
     gtError() << __func__ << tr("-> Cannot get parameter %1 of entry %2"
@@ -1084,10 +1081,11 @@ GtpyDecorator::getPropertyContainerEntryIds(GtObject* obj,
 
     QStringList retVal;
 
-    for (int var = 0; var < s->size(); ++var)
-    {
-        retVal << s->at(var).ident();
-    }
+    std::transform(s->begin(), s->end(), std::back_inserter(retVal),
+                   [](const auto& v)
+                   {
+                       return v.ident();
+                   });
 
     return retVal;
 }
@@ -1133,14 +1131,11 @@ GtpyDecorator::setPropertyContainerVal(GtObject* obj, const QString& id,
         return false;
     }
 
-    for (int index = 0; index < s->size(); ++index)
-    {
-        if (s->at(index).ident() == entryId)
-        {
-            GtPropertyStructInstance& structCon = s->at(index);
+    GtPropertyStructContainer::iterator it = s->findEntry(entryId);
 
-            return structCon.setMemberVal(memberId, val);
-        }
+    if (it != s->end())
+    {
+        return it->setMemberVal(memberId, val);
     }
 
     gtError() << __func__ << tr("-> Cannot set parameter %1 of entry %2"

--- a/src/module/utilities/gtpy_decorator.cpp
+++ b/src/module/utilities/gtpy_decorator.cpp
@@ -1037,11 +1037,12 @@ GtpyDecorator::getPropertyContainerVal(GtObject* obj, QString const& id,
 
     return structCon.getMemberValToVariant(memberId);
 }
+
 QVariant
-GtpyDecorator::getPropertyContainerVal (GtObject* obj,
-                                        const QString& id,
-                                        const QString& entryId,
-                                        const QString& memberId)
+GtpyDecorator::getPropertyContainerVal(GtObject* obj,
+                                       const QString& id,
+                                       const QString& entryId,
+                                       const QString& memberId)
 {
     GtPropertyStructContainer* s = structContainerOfObject(obj, id);
 

--- a/src/module/utilities/gtpy_decorator.cpp
+++ b/src/module/utilities/gtpy_decorator.cpp
@@ -1037,6 +1037,59 @@ GtpyDecorator::getPropertyContainerVal(GtObject* obj, QString const& id,
 
     return structCon.getMemberValToVariant(memberId);
 }
+QVariant
+GtpyDecorator::getPropertyContainerVal (GtObject* obj,
+                                        const QString& id,
+                                        const QString& entryId,
+                                        const QString& memberId)
+{
+    GtPropertyStructContainer* s = structContainerOfObject(obj, id);
+
+    if (!s)
+    {
+        gtError() << __func__ << " -> PropertyStruct container of "
+                                 "object not found!";
+        return {};
+    }
+
+    for (int index = 0; index < s->size(); ++index)
+    {
+        if (s->at(index).ident() == entryId)
+        {
+            GtPropertyStructInstance& structCon = s->at(index);
+
+            return structCon.getMemberValToVariant(memberId);
+        }
+    }
+
+    gtError() << __func__ << tr("-> Cannot get parameter %1 of entry %2"
+                                "in container %3").arg(memberId, entryId, id);
+
+    return {};
+}
+
+QStringList
+GtpyDecorator::getPropertyContainerEntryIds(GtObject* obj,
+                                            const QString& containerId)
+{
+    GtPropertyStructContainer* s = structContainerOfObject(obj, containerId);
+
+    if (!s)
+    {
+        gtError() << __func__ << " -> PropertyStruct container of "
+                                 "object not found!";
+        return {};
+    }
+
+    QStringList retVal;
+
+    for (int var = 0; var < s->size(); ++var)
+    {
+        retVal << s->at(var).ident();
+    }
+
+    return retVal;
+}
 
 bool
 GtpyDecorator::setPropertyContainerVal(GtObject* obj, const QString& id,
@@ -1059,11 +1112,42 @@ GtpyDecorator::setPropertyContainerVal(GtObject* obj, const QString& id,
         return false;
     }
 
-
     GtPropertyStructInstance& structCon = s->at(index);
 
     return structCon.setMemberVal(memberId, val);
 }
+
+bool
+GtpyDecorator::setPropertyContainerVal(GtObject* obj, const QString& id,
+                                       const QString& entryId,
+                                       const QString& memberId,
+                                       const QVariant& val)
+{
+    GtPropertyStructContainer* s = structContainerOfObject(obj, id);
+
+    if (!s)
+    {
+        gtError() << __func__ << " -> PropertyStruct container of "
+                                 "object not found!";
+        return false;
+    }
+
+    for (int index = 0; index < s->size(); ++index)
+    {
+        if (s->at(index).ident() == entryId)
+        {
+            GtPropertyStructInstance& structCon = s->at(index);
+
+            return structCon.setMemberVal(memberId, val);
+        }
+    }
+
+    gtError() << __func__ << tr("-> Cannot set parameter %1 of entry %2"
+                                "in container %3").arg(memberId, entryId, id);
+
+    return false;
+}
+
 #endif
 QList<GtAbstractProperty*>
 GtpyDecorator::findGtProperties(GtObject* obj)

--- a/src/module/utilities/gtpy_decorator.h
+++ b/src/module/utilities/gtpy_decorator.h
@@ -431,12 +431,9 @@ public slots:
                                       int index, const QString& memberId);
 
     /**
-     * Same as above, but uses the ident of the property entry to find it
-     */
-
-    /**
      * @brief Find a struct container property and return a value of
-     * a defined propety
+     * a defined property. This function uses the id string of the
+     * container element.
      *
      * @param obj - parent object of the struct propety
      * @param id of the property struct container

--- a/src/module/utilities/gtpy_decorator.h
+++ b/src/module/utilities/gtpy_decorator.h
@@ -434,12 +434,29 @@ public slots:
     /**
      * Same as above, but uses the ident of the property entry to find it
      */
+
+    /**
+     * @brief getPropertyContainerVal
+     * Find a struct container property and return a value of
+     * a defined propety
+     * @param obj - parent object of the struct propety
+     * @param id of the property struct container
+     * @param entryId - id of the entry to read the value from.
+     * In contrast to function above this function does not use the index
+     * @param memberId of the property to call
+     * @return the value as a variant - empty for invalid inputs
+     *
+     * Example call in python:
+     *  task.getPropertyContainerVal("constraints", "minEta", "value")
+     */
     QVariant getPropertyContainerVal(GtObject* obj, const QString& id,
                                      const QString& entryId,
                                      const QString& memberId);
 
     /**
      * @brief getPropertyContainerEntryIds
+     * Returns a list with all property entry ids of a given container element
+     * The container element is specified by its containerId
      * @param obj - object which has the property container
      * @param containerId - Id of the property container to evaluate
      * @return a ist of all ids of the contained properties
@@ -462,7 +479,16 @@ public slots:
                                  QString const& memberId, const QVariant& val);
 
     /**
-     * Same as above, but uses the ident of the property entry to find it
+     * @brief setPropertyContainerVal
+     * Find a struct container property and sets a value of
+     * a defined propety
+     * @param obj - parent object of the struct propety
+     * @param id of the property struct container
+     * @param entryId - Id of the container element to modify. Incontrast to the
+     * function above the elment is determined by id and not by index
+     * @param memberId of the property to call
+     * @param val - value to set
+     * @return true in case of success, else false
      */
     bool setPropertyContainerVal(GtObject* obj, QString const& id,
                                  const QString& entryId,

--- a/src/module/utilities/gtpy_decorator.h
+++ b/src/module/utilities/gtpy_decorator.h
@@ -424,7 +424,6 @@ public slots:
      * @param index of the element of the items of the container
      * @param memberId of the property to call
      * @return the value as a variant - empty for invalid inputs
-     *
      * Example call in python:
      *  task.getPropertyContainerVal("args_input", 0, "name")
      */
@@ -436,16 +435,14 @@ public slots:
      */
 
     /**
-     * @brief getPropertyContainerVal
-     * Find a struct container property and return a value of
+     * @brief Find a struct container property and return a value of
      * a defined propety
+     *
      * @param obj - parent object of the struct propety
      * @param id of the property struct container
      * @param entryId - id of the entry to read the value from.
-     * In contrast to function above this function does not use the index
      * @param memberId of the property to call
      * @return the value as a variant - empty for invalid inputs
-     *
      * Example call in python:
      *  task.getPropertyContainerVal("constraints", "minEta", "value")
      */
@@ -479,13 +476,11 @@ public slots:
                                  QString const& memberId, const QVariant& val);
 
     /**
-     * @brief setPropertyContainerVal
-     * Find a struct container property and sets a value of
+     * @brief Find a struct container property and sets a value of
      * a defined propety
      * @param obj - parent object of the struct propety
      * @param id of the property struct container
-     * @param entryId - Id of the container element to modify. Incontrast to the
-     * function above the elment is determined by id and not by index
+     * @param entryId - Id of the container element to modify.
      * @param memberId of the property to call
      * @param val - value to set
      * @return true in case of success, else false

--- a/src/module/utilities/gtpy_decorator.h
+++ b/src/module/utilities/gtpy_decorator.h
@@ -423,13 +423,29 @@ public slots:
      * @param id of the property struct container
      * @param index of the element of the items of the container
      * @param memberId of the property to call
-     * @return the value as a variant
+     * @return the value as a variant - empty for invalid inputs
      *
      * Example call in python:
      *  task.getPropertyContainerVal("args_input", 0, "name")
      */
     QVariant getPropertyContainerVal (GtObject* obj, const QString& id,
-                                    int index, const QString& memberId);
+                                      int index, const QString& memberId);
+
+    /**
+     * Same as above, but uses the ident of the property entry to find it
+     */
+    QVariant getPropertyContainerVal(GtObject* obj, const QString& id,
+                                     const QString& entryId,
+                                     const QString& memberId);
+
+    /**
+     * @brief getPropertyContainerEntryIds
+     * @param obj - object which has the property container
+     * @param containerId - Id of the property container to evaluate
+     * @return a ist of all ids of the contained properties
+     */
+    QStringList getPropertyContainerEntryIds(GtObject* obj,
+                                             const QString& containerId);
 
     /**
      * @brief setPropertyContainerVal
@@ -443,6 +459,13 @@ public slots:
      * @return true in case of success, else false
      */
     bool setPropertyContainerVal(GtObject* obj, QString const& id, int index,
+                                 QString const& memberId, const QVariant& val);
+
+    /**
+     * Same as above, but uses the ident of the property entry to find it
+     */
+    bool setPropertyContainerVal(GtObject* obj, QString const& id,
+                                 const QString& entryId,
                                  QString const& memberId, const QVariant& val);
 #endif
     /**

--- a/src/module/utilities/gtpy_moduleupgrader.cpp
+++ b/src/module/utilities/gtpy_moduleupgrader.cpp
@@ -1,0 +1,20 @@
+/* GTlab - Gas Turbine laboratory
+ * Source File: gtpy_code.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: 2025 German Aerospace Center (DLR)
+ *
+ * Created on: 14.11.2025
+ * Author: Jens Schmeink (DLR AT-TWK)
+ */
+
+#include "gtpy_moduleupgrader.h"
+
+#include "gt_logging.h"
+
+bool
+gtpy::module_upgrader::to_2_0_0::run(QDomElement& root,
+                                     const QString& targetPath)
+{
+    gtDebug() << "Do upgrade for file" << targetPath;
+}

--- a/src/module/utilities/gtpy_moduleupgrader.cpp
+++ b/src/module/utilities/gtpy_moduleupgrader.cpp
@@ -108,6 +108,10 @@ gtpy::module_upgrader::to_2_0_0::run(QDomElement& root,
     QList<QDomElement> calcElements;
     findElementsByClass(root, {"GtpyScriptCalculator", "GtpyTask"}, calcElements);
 
+    if (calcElements.isEmpty()) return true;
+
+    gtTrace() << QObject::tr("Update task file") << targetPath;
+
     for (auto e : calcElements)
     {
         normalizePropertyContainer(e);

--- a/src/module/utilities/gtpy_moduleupgrader.cpp
+++ b/src/module/utilities/gtpy_moduleupgrader.cpp
@@ -19,6 +19,22 @@ namespace {
                              QList<QDomElement>& results,
                              bool allowNestedClassElements = false)
     {
+        if (node.isElement())
+        {
+            QDomElement elem = node.toElement();
+            if (!elem.isNull())
+            {
+                QString c = elem.attribute("class");
+
+                if (classNames.contains(c))
+                {
+                    results.append(elem);
+
+                    if (!allowNestedClassElements) return;
+                }
+            }
+        }
+
         QDomNode child = node.firstChild();
         while (!child.isNull())
         {

--- a/src/module/utilities/gtpy_moduleupgrader.cpp
+++ b/src/module/utilities/gtpy_moduleupgrader.cpp
@@ -12,9 +12,106 @@
 
 #include "gt_logging.h"
 
+namespace {
+
+    void findElementsByClass(const QDomNode& node,
+                             const QStringList& classNames,
+                             QList<QDomElement>& results)
+    {
+        QDomNode child = node.firstChild();
+        while (!child.isNull()) {
+
+            if (child.isElement()) {
+                QDomElement elem = child.toElement();
+
+                if (!elem.isNull()) {
+                    QString classValue = elem.attribute("class");
+
+                    if (classNames.contains(classValue)) {
+                        results.append(elem);
+                        // laut deiner Anforderung:
+                        // solche Einträge haben KEINE weiteren relevanten Untereinträge,
+                        // aber wir durchsuchen trotzdem nicht den Baum *innerhalb* dieses Elements:
+                        child = child.nextSibling();
+                        continue;
+                    }
+                }
+            }
+
+            // rekursiv in die nächste Ebene
+            findElementsByClass(child, classNames, results);
+
+            child = child.nextSibling();
+        }
+    }
+
+    void normalizePropertyContainer(QDomElement container)
+    {
+        QDomNode child = container.firstChild();
+
+        while (!child.isNull()) {
+            if (child.isElement()) {
+                QDomElement prop = child.toElement();
+
+                if (prop.tagName() == "property") {
+
+                    // 1. find sub propety "name"
+                    QDomElement nameElem;
+                    QDomNode sub = prop.firstChild();
+
+                    while (!sub.isNull())
+                    {
+                        if (sub.isElement())
+                        {
+                            QDomElement e = sub.toElement();
+                            if (e.attribute("name") == "name")
+                            {
+                                nameElem = e;
+                                break;
+                            }
+                        }
+                        sub = sub.nextSibling();
+                    }
+
+                    if (!nameElem.isNull())
+                    {
+                        QString newName = nameElem.text().trimmed();
+
+                        // 2. name="UUID" → name="OP"
+                        prop.setAttribute("name", newName);
+
+                        // 3. Remove sub property <property name="name">…</property>
+                        prop.removeChild(nameElem);
+                    }
+                }
+            }
+
+            child = child.nextSibling();
+        }
+    }
+
+}
+
 bool
 gtpy::module_upgrader::to_2_0_0::run(QDomElement& root,
                                      const QString& targetPath)
 {
-    gtDebug() << "Do upgrade for file" << targetPath;
+    // only do updates for process elements
+    if (!targetPath.endsWith(".gttask")) return true;
+
+    if (root.isNull())
+    {
+        gtError() << QObject::tr("Invalid .gttask file!");
+        return false;
+    }
+
+    QList<QDomElement> calcElements;
+    findElementsByClass(root, {"GtpyScriptCalculator", "GtpyTask"}, calcElements);
+
+    for (auto e : calcElements)
+    {
+        normalizePropertyContainer(e);
+    }
+
+    return true;
 }

--- a/src/module/utilities/gtpy_moduleupgrader.h
+++ b/src/module/utilities/gtpy_moduleupgrader.h
@@ -1,0 +1,31 @@
+/* GTlab - Gas Turbine laboratory
+ * Source File: gtpy_code.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: 2025 German Aerospace Center (DLR)
+ *
+ * Created on: 14.11.2025
+ * Author: Jens Schmeink (DLR AT-TWK)
+ */
+#ifndef GTPY_MODULEUPGRADER_H
+#define GTPY_MODULEUPGRADER_H
+
+#include <QDomElement>
+
+namespace gtpy {
+
+namespace module_upgrader {
+
+namespace to_2_0_0 {
+    /**
+    * @brief Performs the upgrade to predign data model 3.0.0
+    *
+    * @return true in case of success
+    */
+    bool run(QDomElement& root, const QString& targetPath);
+} // to_2_0_0
+} // module_upgrader
+} // gtpy
+
+
+#endif // GTPY_MODULEUPGRADER_H

--- a/src/module/utilities/gtpy_transfer.cpp
+++ b/src/module/utilities/gtpy_transfer.cpp
@@ -65,7 +65,11 @@ gtpy::transfer::propStructToPython(
 
     for (const auto& instance : container)
     {
+#if GT_VERSION >= GT_VERSION_CHECK(2, 1, 0)
+        auto name = instance.ident();
+#else
         auto name = instance.getMemberVal<QString>("name");
+#endif
 
         if (!name.isEmpty())
         {
@@ -92,8 +96,11 @@ gtpy::transfer::propStructFromPython(
 
     for (auto& entry : container)
     {
+#if GT_VERSION >= GT_VERSION_CHECK(2, 1, 0)
+        auto argName = entry.ident();
+#else
         auto argName = entry.getMemberVal<QString>("name");
-
+#endif
         auto iter = dict.find(argName);
         if (iter != dict.end())
         {


### PR DESCRIPTION
The new development of container properties for GTlab which now can be handled via names instead of indices are beneficial for usage in python process elements.

As this changes the datamodel an module upgrader is needed aswell to convert old projects to the new structure