### PR TITLE
Introduce centralized shortcut handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    it returns only the modules that are part of the data model of the current project. - #630
  - Fixed a crash when creating a calculator with missing author information in a Python Task - #627
 
+### Added
+ - Python Module shortcuts are now registered in GTlab’s shortcut list.
+
 ## [1.8.0] - 2025-07-11
 
 ### Fixed

--- a/src/module/CMakeLists.txt
+++ b/src/module/CMakeLists.txt
@@ -62,6 +62,7 @@ set(HEADERS
     utilities/gtpy_processdatadistributor.h
     utilities/gtpy_regexp.h
     utilities/gtpy_scriptrunnable.h
+    utilities/gtpy_shortcut.h
     utilities/gtpy_utils.h
     utilities/gtpy_tempdir.h
     utilities/gtpy_transfer.h
@@ -134,6 +135,7 @@ set(SOURCES
     utilities/gtpy_processdatadistributor.cpp
     utilities/gtpy_regexp.cpp
     utilities/gtpy_scriptrunnable.cpp
+    utilities/gtpy_shortcut.cpp
     utilities/gtpy_utils.cpp
     utilities/gtpy_tempdir.cpp
     utilities/gtpy_transfer.cpp

--- a/src/module/gt_python.cpp
+++ b/src/module/gt_python.cpp
@@ -55,6 +55,7 @@
 #include "gt_accessdataconnection.h"
 
 #include "gtpy_scriptcollectionsettings.h"
+#include "gtpy_shortcut.h"
 
 #include "gt_python.h"
 
@@ -161,6 +162,8 @@ GtPythonModule::init()
     {
         gtError() << "Unable to register matplotlib backend. Is matplotlib installed?";
     }
+
+    gtpy::shortcut::registerShortCuts();
 }
 
 QList<GtCalculatorData>

--- a/src/module/utilities/gtpy_shortcut.cpp
+++ b/src/module/utilities/gtpy_shortcut.cpp
@@ -28,7 +28,6 @@ void registerShortCuts()
 
     registerShortCut(id::EVAL, {Qt::CTRL + Qt::Key_E});
     registerShortCut(id::INTERRUPT, {Qt::CTRL + Qt::Key_I});
-    registerShortCut(id::SAVE, {Qt::CTRL + Qt::Key_S});
 }
 
 } // shortcut

--- a/src/module/utilities/gtpy_shortcut.cpp
+++ b/src/module/utilities/gtpy_shortcut.cpp
@@ -19,8 +19,8 @@ namespace shortcut
 void registerShortCuts()
 {
     auto registerShortCut = [](auto id, QKeySequence shortcut) {
-#if GT_VERSION >= 0x020100
-        gtApp->addShortCut(id, cat::PY_MODULE, shortcut, true);
+#if GT_VERSION >= GT_VERSION_CHECK(2, 1, 0)
+        gtApp->addShortCut(id, category::PY_MODULE, shortcut, true);
 #else
         gtApp->extendShortCuts({id, category::PY_MODULE, shortcut, true});
 #endif

--- a/src/module/utilities/gtpy_shortcut.cpp
+++ b/src/module/utilities/gtpy_shortcut.cpp
@@ -1,0 +1,36 @@
+/* GTlab - Gas Turbine laboratory
+ * Source File: gtpy_shortcut.cpp
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: 2025 German Aerospace Center (DLR)
+ *
+ * Created on: 01.12.2025
+ * Author: Marvin Noethen (DLR AT-TWK)
+ */
+
+#include "gtpy_shortcut.h"
+
+namespace gtpy
+{
+
+namespace shortcut
+{
+
+void registerShortCuts()
+{
+    auto registerShortCut = [](auto id, QKeySequence shortcut) {
+#if GT_VERSION >= 0x020100
+        gtApp->addShortCut(id, cat::PY_MODULE, shortcut, true);
+#else
+        gtApp->extendShortCuts({id, category::PY_MODULE, shortcut, true});
+#endif
+    };
+
+    registerShortCut(id::EVAL, {Qt::CTRL + Qt::Key_E});
+    registerShortCut(id::INTERRUPT, {Qt::CTRL + Qt::Key_I});
+    registerShortCut(id::SAVE, {Qt::CTRL + Qt::Key_S});
+}
+
+} // shortcut
+
+} // namespace gtpy

--- a/src/module/utilities/gtpy_shortcut.h
+++ b/src/module/utilities/gtpy_shortcut.h
@@ -65,15 +65,6 @@ inline QKeySequence interrupt()
 }
 
 /**
- * @brief Returns the QKeySequence for the "Save Script" shortcut.
- * @return The currently configured key sequence.
- */
-inline QKeySequence save()
-{
-    return gtApp->getShortCutSequence(id::SAVE, category::PY_MODULE);
-}
-
-/**
  * @brief Returns the "Evaluate Script" shortcut as a QString.
  * @return The currently configured shortcut as a string.
  */
@@ -89,15 +80,6 @@ inline QString evalStr()
 inline QString interruptStr()
 {
     return interrupt().toString();
-}
-
-/**
- * @brief Returns the "Save Script" shortcut as a QString.
- * @return The currently configured shortcut as a string.
- */
-inline QString saveStr()
-{
-    return save().toString();
 }
 
 /**
@@ -129,16 +111,6 @@ inline QString evalLabelText()
 inline QString interruptLabelText()
 {
     return labelText(interruptStr());
-}
-
-/**
- * @brief Returns the "Save Script" shortcut as an HTML-formatted string.
- * @return The currently configured "Save Script" shortcut formatted for
- * display.
- */
-inline QString saveLabelText()
-{
-    return labelText(saveStr());
 }
 
 } // shortcut

--- a/src/module/utilities/gtpy_shortcut.h
+++ b/src/module/utilities/gtpy_shortcut.h
@@ -1,0 +1,148 @@
+/* GTlab - Gas Turbine laboratory
+ * Source File: gtpy_shortcut.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: 2025 German Aerospace Center (DLR)
+ *
+ * Created on: 01.12.2025
+ * Author: Marvin Noethen (DLR AT-TWK)
+ */
+
+#ifndef GTPY_SHORTCUTS_H
+#define GTPY_SHORTCUTS_H
+
+#include <QKeySequence>
+
+#include <gt_application.h>
+
+namespace gtpy
+{
+
+namespace shortcut
+{
+
+namespace category
+{
+
+constexpr const char* PY_MODULE = "Python Module";
+
+} // namespace category
+
+namespace id
+{
+
+constexpr const char* EVAL = "evaluateScript";
+constexpr const char* INTERRUPT = "interruptEvaluation";
+constexpr const char* SAVE = "saveScript";
+
+} // namespace id
+
+/**
+ * @brief Registers the Python Module's standard shortcuts in GTlab's shortcut
+ * list.
+ *
+ * It should be called in the init() method of the Python Module.
+ */
+void registerShortCuts();
+
+
+/**
+ * @brief Returns the QKeySequence for the "Evaluate Script" shortcut.
+ * @return The currently configured key sequence.
+ */
+inline QKeySequence eval()
+{
+    return gtApp->getShortCutSequence(id::EVAL, category::PY_MODULE);
+}
+
+/**
+ * @brief Returns the QKeySequence for the "Interrupt Evaluation" shortcut.
+ * @return The currently configured key sequence.
+ */
+inline QKeySequence interrupt()
+{
+    return gtApp->getShortCutSequence(id::INTERRUPT, category::PY_MODULE);
+}
+
+/**
+ * @brief Returns the QKeySequence for the "Save Script" shortcut.
+ * @return The currently configured key sequence.
+ */
+inline QKeySequence save()
+{
+    return gtApp->getShortCutSequence(id::SAVE, category::PY_MODULE);
+}
+
+/**
+ * @brief Returns the "Evaluate Script" shortcut as a QString.
+ * @return The currently configured shortcut as a string.
+ */
+inline QString evalStr()
+{
+    return eval().toString();
+}
+
+/**
+ * @brief Returns the "Interrupt Evaluation" shortcut as a QString.
+ * @return The currently configured shortcut as a string.
+ */
+inline QString interruptStr()
+{
+    return interrupt().toString();
+}
+
+/**
+ * @brief Returns the "Save Script" shortcut as a QString.
+ * @return The currently configured shortcut as a string.
+ */
+inline QString saveStr()
+{
+    return save().toString();
+}
+
+/**
+ * @brief Formats a shortcut string for display in the GUI.
+ * @param shortCutStr The shortcut string to format.
+ * @return The HTML-formatted shortcut string.
+ */
+inline QString labelText(const QString& shortCutStr)
+{
+    return QStringLiteral("<font color='grey'>  (%1)</font>").arg(shortCutStr);
+}
+
+/**
+ * @brief Returns the "Evaluate Script" shortcut as an HTML-formatted string.
+ * @return The currently configured "Evaluate Script" shortcut formatted for
+ * display.
+ */
+inline QString evalLabelText()
+{
+    return labelText(evalStr());
+}
+
+/**
+ * @brief Returns the "Interrupt Evaluation" shortcut as an HTML-formatted
+ * string.
+ * @return The currently configured "Interrupt Evaluation" shortcut formatted
+ * for display.
+ */
+inline QString interruptLabelText()
+{
+    return labelText(interruptStr());
+}
+
+/**
+ * @brief Returns the "Save Script" shortcut as an HTML-formatted string.
+ * @return The currently configured "Save Script" shortcut formatted for
+ * display.
+ */
+inline QString saveLabelText()
+{
+    return labelText(saveStr());
+}
+
+} // shortcut
+
+} // namespace gtpy
+
+#endif // GTPY_SHORTCUTS_H

--- a/src/module/wizards/gtpy_abstractscriptingwizardpage.cpp
+++ b/src/module/wizards/gtpy_abstractscriptingwizardpage.cpp
@@ -187,7 +187,7 @@ GtpyAbstractScriptingWizardPage::GtpyAbstractScriptingWizardPage(
     toolBarLayout->addStretch(1);
 
     //Save Button
-    m_shortCutSave = new QLabel(gtpy::shortcut::saveLabelText());
+    m_shortCutSave = new QLabel("<font color='grey'> Ctrl+S</font>");
     QFont fontSave = m_shortCutSave->font();
     fontSave.setItalic(true);
     fontSave.setPointSize(7);
@@ -750,7 +750,7 @@ GtpyAbstractScriptingWizardPage::enableSaveButton(bool enable)
 
     if (enable)
     {
-        m_shortCutSave->setText(gtpy::shortcut::saveLabelText());
+        m_shortCutSave->setText("<font color='grey'> Ctrl+S</font>");
     }
     else
     {

--- a/src/module/wizards/gtpy_abstractscriptingwizardpage.cpp
+++ b/src/module/wizards/gtpy_abstractscriptingwizardpage.cpp
@@ -34,6 +34,7 @@
 #include "gtpy_editorsettingsdialog.h"
 #include "gtpy_packageiteration.h"
 #include "gtpy_transfer.h"
+#include "gtpy_shortcut.h"
 
 // GTlab framework includes
 #include "gt_object.h"
@@ -170,7 +171,7 @@ GtpyAbstractScriptingWizardPage::GtpyAbstractScriptingWizardPage(
     m_evalButton->setIcon(GTPY_ICON(play));
     m_evalButton->setToolTip(tr("Evaluate Python script"));
 
-    m_shortCutEval = new QLabel("<font color='grey'>  Ctrl+E</font>");
+    m_shortCutEval = new QLabel(gtpy::shortcut::evalLabelText());
     QFont font = m_shortCutEval->font();
     font.setItalic(true);
     font.setPointSize(7);
@@ -186,7 +187,7 @@ GtpyAbstractScriptingWizardPage::GtpyAbstractScriptingWizardPage(
     toolBarLayout->addStretch(1);
 
     //Save Button
-    m_shortCutSave = new QLabel("<font color='grey'>  Ctrl+S</font>");
+    m_shortCutSave = new QLabel(gtpy::shortcut::saveLabelText());
     QFont fontSave = m_shortCutSave->font();
     fontSave.setItalic(true);
     fontSave.setPointSize(7);
@@ -749,7 +750,7 @@ GtpyAbstractScriptingWizardPage::enableSaveButton(bool enable)
 
     if (enable)
     {
-        m_shortCutSave->setText("<font color='grey'>  Ctrl+S</font>");
+        m_shortCutSave->setText(gtpy::shortcut::saveLabelText());
     }
     else
     {
@@ -928,14 +929,14 @@ GtpyAbstractScriptingWizardPage::showEvalButton(bool show)
         m_evalButton->setIcon(GTPY_ICON(play));
         m_evalButton->setToolTip(tr("Evaluate Python script"));
 
-        m_shortCutEval->setText("<font color='grey'>  Ctrl+E</font>");
+        m_shortCutEval->setText(gtpy::shortcut::evalLabelText());
     }
     else
     {
         m_evalButton->setIcon(GTPY_ICON(stop));
         m_evalButton->setToolTip(tr("Interrupt evaluation"));
 
-        m_shortCutEval->setText("<font color='grey'>  Ctrl+I</font>");
+        m_shortCutEval->setText(gtpy::shortcut::interruptLabelText());
     }
 }
 


### PR DESCRIPTION
This PR introduces a centralized shortcut handling for the Python Module.

All module-related shortcuts (Evaluate Script and Interrupt Evaluation) are now registered in GTlab’s shortcut list and accessed through centralized functions. This ensures consistent shortcut usage across the Python Module.

Closes #641