### PR TITLE
Refactor Python wizard save behavior and automate script transfer to the corresponding data model object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Fixed a crash when creating a calculator with missing author information in a Python Task - #627
 
 ### Changed
- - Python Task and Calculator wizards now automatically save changes from the editor to
-   the corresponding data model whenever the wizard loses focus or is closed.
+ - Python Task and Calculator wizards now automatically transfer changes from the editor to
+   the corresponding data model object whenever the wizard loses focus or is closed.
  - Removed the `Save` and `Cancel` buttons as well as the "Do you want to save..." message box,
    since manual saving is no longer required. All changes can be undone via GTlab's Undo/Redo system. - #86
  - The script editor in the wizard now updates automatically when Undo/Redo is performed in the main GUI.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    it returns only the modules that are part of the data model of the current project. - #630
  - Fixed a crash when creating a calculator with missing author information in a Python Task - #627
 
+### Changed
+ - Python Task and Calculator wizards now automatically save changes from the editor to
+   the corresponding data model whenever the wizard loses focus or is closed.
+ - Removed the `Save` and `Cancel` buttons as well as the "Do you want to save..." message box,
+   since manual saving is no longer required. All changes can be undone via GTlab's Undo/Redo system. - #86
+ - The script editor in the wizard now updates automatically when Undo/Redo is performed in the main GUI.
+
 ## [1.8.0] - 2025-07-11
 
 ### Fixed

--- a/src/module/processcomponents/gtpy_abstractscriptcomponent.cpp
+++ b/src/module/processcomponents/gtpy_abstractscriptcomponent.cpp
@@ -226,6 +226,12 @@ GtpyAbstractScriptComponent::outputArg(const QString& argName) const
 }
 #endif
 
+const GtStringProperty&
+GtpyAbstractScriptComponent::scriptProp() const
+{
+    return m_script;
+}
+
 bool
 GtpyAbstractScriptComponent::evalScript(int contextId)
 {

--- a/src/module/processcomponents/gtpy_abstractscriptcomponent.h
+++ b/src/module/processcomponents/gtpy_abstractscriptcomponent.h
@@ -108,6 +108,12 @@ public:
     QVariant outputArg(const QString& argName) const;
 #endif
 
+    /**
+     * @brief Returns the script property.
+     * @return Constant reference to the script property.
+     */
+    const GtStringProperty& scriptProp() const;
+
 protected:
     /**
      * @brief GtpyComponentAssistant

--- a/src/module/wizards/gtpy_abstractscriptingwizardpage.cpp
+++ b/src/module/wizards/gtpy_abstractscriptingwizardpage.cpp
@@ -687,11 +687,11 @@ GtpyAbstractScriptingWizardPage::validation()
 void
 GtpyAbstractScriptingWizardPage::saveScript()
 {
-    applyScriptToDataModel();
+    storeScriptInDataModel();
 }
 
 void
-GtpyAbstractScriptingWizardPage::applyScriptToDataModel() const
+GtpyAbstractScriptingWizardPage::storeScriptInDataModel() const
 {
     GtObject* obj = gtDataModel->objectByUuid(componentUuid());
     if (!obj) return;
@@ -871,13 +871,16 @@ GtpyAbstractScriptingWizardPage::cursorToNewLine()
 bool
 GtpyAbstractScriptingWizardPage::eventFilter(QObject* watched, QEvent* event)
 {
-    if (!event) return GtProcessWizardPage::eventFilter(watched, event);
+    if (!watched || !event)
+    {
+        return GtProcessWizardPage::eventFilter(watched, event);
+    }
 
     switch (event->type())
     {
     // this event occurs when the wizard loses focus
     case QEvent::WindowDeactivate:
-        if (watched == wizard()) applyScriptToDataModel();
+        if (watched == wizard()) storeScriptInDataModel();
         break;
 
     default:

--- a/src/module/wizards/gtpy_abstractscriptingwizardpage.h
+++ b/src/module/wizards/gtpy_abstractscriptingwizardpage.h
@@ -204,7 +204,7 @@ protected:
     /**
      * To intercept closing events
      */
-    bool eventFilter(QObject *watched, QEvent *event) override;
+    bool eventFilter(QObject* watched, QEvent* event) override;
 
     /// Python Context type
     GtpyContextManager::Context m_contextType;
@@ -235,13 +235,13 @@ private:
     virtual bool validation();
 
     /**
-     * @brief Calls applyScriptToDataModel() to apply the current script
+     * @brief Calls storeScriptInDataModel() to apply the current script
      * from the editor to the data model.
      *
      * This method is retained for backward compatibility.
-     * Use applyScriptToDataModel() directly instead.
+     * Use storeScriptInDataModel() directly instead.
      */
-    [[deprecated("Use applyScriptToDataModel() instead")]]
+    [[deprecated("Use storeScriptInDataModel() instead")]]
     virtual void saveScript() final;
 
     /**
@@ -275,7 +275,7 @@ private:
     /**
      * @brief Applies the current script from the editor to the data model.
      */
-    void applyScriptToDataModel() const;
+    void storeScriptInDataModel() const;
 
     /**
      * @brief Sets the window modality of the wizard to non modal. This allows

--- a/src/module/wizards/gtpy_abstractscriptingwizardpage.h
+++ b/src/module/wizards/gtpy_abstractscriptingwizardpage.h
@@ -107,7 +107,7 @@ protected:
      * @brief Returns current text in editor widget.
      * @return current text in editor widget
      */
-    QString editorText();
+    QString editorText() const;
 
     /**
      * @brief Replaces the calculator settings between header and caption with
@@ -198,13 +198,6 @@ protected:
      */
     void cursorToNewLine();
 
-    /**
-     * @brief Enable or disable the saving functionality.
-     * @param enable Whether the saving functionality should be enabled or
-     *  disabled.
-     */
-    void enableSaving(bool enable = true);
-
     /// Python Context id
     int m_contextId;
 
@@ -242,10 +235,14 @@ private:
     virtual bool validation();
 
     /**
-     * @brief In this pure virtual function the routine for saving a script
-     * must be implemented.
+     * @brief Calls applyScriptToDataModel() to apply the current script
+     * from the editor to the data model.
+     *
+     * This method is retained for backward compatibility.
+     * Use applyScriptToDataModel() directly instead.
      */
-    virtual void saveScript() = 0;
+    [[deprecated("Use applyScriptToDataModel() instead")]]
+    virtual void saveScript() final;
 
     /**
      * @brief This pure virtual function must return the uuid of the restored
@@ -276,16 +273,9 @@ private:
     virtual void saveSettings(GtpyEditorSettings* pref) = 0;
 
     /**
-     * @brief Enables of disables the save button.
-     * @param enable If true, the Save button is enabled, otherwise it is
-     *  disabled.
+     * @brief Applies the current script from the editor to the data model.
      */
-    void enableSaveButton(bool enable = true);
-
-    /**
-     * @brief saveMesssageBox
-     */
-    int saveMessageBox();
+    void applyScriptToDataModel() const;
 
     /**
      * @brief Sets the window modality of the wizard to non modal. This allows
@@ -341,12 +331,6 @@ private:
     /// Interrupt shortcut lable
     QLabel* m_shortCutInterrupt;
 
-    /// Save Button
-    QPushButton* m_saveButton;
-
-    /// Save shortcut label
-    QLabel* m_shortCutSave;
-
     /// Console Clear Button
     QPushButton* m_consoleClearButton;
 
@@ -372,9 +356,6 @@ private:
 
     /// Script runnable for evaluation
     QPointer<GtpyScriptRunnable> m_runnable;
-
-    /// Saving the script
-    bool m_savingEnabled;
 
     /// Process component uuid
     QString m_componentUuid;
@@ -442,16 +423,6 @@ private slots:
      * function.
      */
     void onEvalShortCutTriggered();
-
-    /**
-     * @brief It saves the current script.
-     */
-    void onSaveButtonClicked();
-
-    /**
-     * @brief Enables the save button.
-     */
-    void onTextChanged();
 
     /**
      * @brief Checks if the evaluation was successful.

--- a/src/module/wizards/python_task/gtpy_taskwizardpage.cpp
+++ b/src/module/wizards/python_task/gtpy_taskwizardpage.cpp
@@ -38,7 +38,6 @@
 #include "gt_project.h"
 #include "gt_calculatorprovider.h"
 #include "gt_processwizard.h"
-#include "gt_command.h"
 #include "gt_application.h"
 #include "gt_deleteitemmessagebox.h"
 #include "gt_calculator.h"
@@ -156,11 +155,6 @@ GtpyTaskWizardPage::initialization()
     gtpy::transfer::propStructToPython(m_contextId, m_task->outputArgs());
 #endif
 
-    if (!gtDataModel->objectByUuid(m_task->uuid()))
-    {
-        enableSaving(false);
-    }
-
     enableCalculators(m_task);
 
     m_task->setFlag(GtObject::NewlyCreated, false);
@@ -233,36 +227,6 @@ GtpyTaskWizardPage::validation()
     provider()->setComponentData(m_task->toMemento());
 
     return true;
-}
-
-void
-GtpyTaskWizardPage::saveScript()
-{
-    if (!m_task)
-    {
-        return;
-    }
-
-    m_task->setScript(editorText());
-
-    GtObjectMemento memento = m_task->toMemento();
-
-    if (memento.isNull())
-    {
-        return;
-    }
-
-    GtObject* obj = gtDataModel->objectByUuid(m_task->uuid());
-
-    if (GtTask* task = qobject_cast<GtTask*>(obj))
-    {
-        GtCommand command =
-            gtApp->startCommand(gtApp->currentProject(),
-                                task->objectName() +
-                                tr(" configuration changed"));
-        task->fromMemento(memento);
-        gtApp->endCommand(command);
-    }
 }
 
 QString

--- a/src/module/wizards/python_task/gtpy_taskwizardpage.h
+++ b/src/module/wizards/python_task/gtpy_taskwizardpage.h
@@ -58,11 +58,6 @@ private:
     virtual bool validation() override;
 
     /**
-     * @brief Saves the script into the task instance.
-     */
-    virtual void saveScript() override;
-
-    /**
      * @brief Returns the uuid of the restored GtpyScriptCalculator.
      * @return uuid of the restored GtpyScriptCalculator
      */

--- a/src/module/wizards/script_calculator/gtpy_scriptcalculatorwizardpage.cpp
+++ b/src/module/wizards/script_calculator/gtpy_scriptcalculatorwizardpage.cpp
@@ -10,10 +10,6 @@
 
 
 // GTlab framework includes
-#include "gt_datamodel.h"
-#include "gt_command.h"
-#include "gt_application.h"
-#include "gt_project.h"
 #include "gt_processfactory.h"
 #include "gt_objectmemento.h"
 #include "gt_abstractprocessprovider.h"
@@ -58,11 +54,6 @@ GtpyScriptCalculatorWizardPage::initialization()
     gtpy::transfer::propStructToPython(m_contextId, m_calc->outputArgs());
 #endif
 
-    if (!gtDataModel->objectByUuid(m_calc->uuid()))
-    {
-        enableSaving(false);
-    }
-
     setPlainTextToEditor(m_calc->script());
 }
 
@@ -78,36 +69,6 @@ GtpyScriptCalculatorWizardPage::validation()
     provider()->setComponentData(m_calc->toMemento());
 
     return true;
-}
-
-void
-GtpyScriptCalculatorWizardPage::saveScript()
-{
-    if (!m_calc)
-    {
-        return;
-    }
-
-    m_calc->setScript(editorText());
-
-    GtObjectMemento memento = m_calc->toMemento();
-
-    if (memento.isNull())
-    {
-        return;
-    }
-
-    auto* obj = gtDataModel->objectByUuid(m_calc->uuid());
-
-    if (auto* calc = qobject_cast<GtCalculator*>(obj))
-    {
-        GtCommand command =
-            gtApp->startCommand(gtApp->currentProject(),
-                                calc->objectName() +
-                                tr(" configuration changed"));
-        calc->fromMemento(memento);
-        gtApp->endCommand(command);
-    }
 }
 
 QString

--- a/src/module/wizards/script_calculator/gtpy_scriptcalculatorwizardpage.h
+++ b/src/module/wizards/script_calculator/gtpy_scriptcalculatorwizardpage.h
@@ -40,11 +40,6 @@ private:
     virtual bool validation() override;
 
     /**
-     * @brief Saves the script into the calculator instance.
-     */
-    virtual void saveScript() override;
-
-    /**
      * @brief Returns the uuid of the restored GtpyScriptCalculator.
      * @return uuid of the restored GtpyScriptCalculator
      */


### PR DESCRIPTION
### Description:

Currently, the Python Task wizard and Python Calculator wizard offer a Python editor with the following behavior:

- `Ctrl+S` is available both globally in GTlab (for saving the project) and in the Python wizard.
- In the Python wizard, `Ctrl+S` only transfers the script from the editor to the data model object (task or calculator); it does not persist the project to disk.
- Closing the wizard via the `Cancel` button discards any changes made since the last `Ctrl+S` in the wizard.
- Closing the wizard via the wizard's close ("X") button opens a "Do you want to save..." message box, which only allows saving or discarding changes made since the last `Ctrl+S` in the wizard.

This leads to confusion for users due to inconsistent save behavior between GTlab's main GUI and the wizard.

### Changes in this PR:
- The `Save` button and `Ctrl+S` shortcut were removed from the wizard to avoid conflicting behaviors.
- The script is now automatically transferred from the editor to the corresponding data model object whenever the wizard loses focus (e.g., the user clicks in the main GUI) or when the wizard is closed.
- The `Cancel` button and the "Do you want to save..." message box were removed, since all changes are now automatically applied to the data model and can be undone via GTlab's Undo/Redo system.

### Benefits:
- Removes confusion caused by different save mechanisms.
- Guarantees that changes in the Python editor are always reflected in the data model.
- Users can edit scripts and execute the corresponding process element immediately without needing to worry about manual saves.
- When the Python Wizard is open and the user clicks Undo/Redo in the main GUI, the script in the wizard's editor is updated to the corresponding change.
