### PR TITLE
Added Qt6 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,6 @@ project(GTlab-Python VERSION 1.5.0)
 
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
-find_package(Qt5 REQUIRED COMPONENTS Widgets Core Gui Xml Svg)
 find_package(Python3 REQUIRED COMPONENTS Development)
 
 set(Python3_VERSION_SUFFIX "${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR}")
@@ -34,6 +33,13 @@ endif()
 
 include(${GTlab_DIR}/GTlab.cmake)
 gtlab_standard_setup()
+
+require_qt(COMPONENTS Widgets Core Gui Xml Svg)
+
+# include SvgWidget, if Qt major version is 6 or higher
+if (QT_VERSION_MAJOR GREATER_EQUAL 6)
+    require_qt(COMPONENTS SvgWidgets)
+endif()
 
 if (GTlab_VERSION_MAJOR LESS 2)
     if (NOT TARGET GTlab::Numerics)

--- a/src/batch/CMakeLists.txt
+++ b/src/batch/CMakeLists.txt
@@ -27,8 +27,8 @@ target_compile_definitions(GTlabPythonConsole PRIVATE
 
 target_link_libraries(GTlabPythonConsole
     PRIVATE
-    Qt5::Widgets
-    Qt5::Xml
+    Qt${QT_VERSION_MAJOR}::Widgets
+    Qt${QT_VERSION_MAJOR}::Xml
     GTlab::Python
 )
 

--- a/src/module/CMakeLists.txt
+++ b/src/module/CMakeLists.txt
@@ -215,15 +215,22 @@ target_include_directories(GTlabPython PUBLIC
 
 target_link_libraries(GTlabPython
     PRIVATE
-    Qt5::Widgets
-    Qt5::Gui
-    Qt5::Xml
-    Qt5::Svg
+    Qt${QT_VERSION_MAJOR}::Widgets
+    Qt${QT_VERSION_MAJOR}::Gui
+    Qt${QT_VERSION_MAJOR}::Xml
+    Qt${QT_VERSION_MAJOR}::Svg
     GTlab::Logging
     GTlab::Core
     PUBLIC
     PythonQt::PythonQt
 )
+
+# include SvgWidgets, if Qt major version is 6 or higher
+if (QT_VERSION_MAJOR GREATER_EQUAL 6)
+    target_link_libraries(GTlabPython
+        PRIVATE Qt6::SvgWidgets
+    )
+endif()
 
 if (GTlab_VERSION_MAJOR GREATER_EQUAL 2)
     target_link_libraries(GTlabPython PRIVATE GTlab::Gui)

--- a/src/module/models/gtpy_completermodel.cpp
+++ b/src/module/models/gtpy_completermodel.cpp
@@ -50,7 +50,7 @@ GtpyCompleterModel::data(const QModelIndex& index, int role) const
 }
 
 void
-GtpyCompleterModel::setFound(const QMap<QString, GtpyFunction>& found)
+GtpyCompleterModel::setFound(const QMultiMap<QString, GtpyFunction>& found)
 {
     m_found = found;
 

--- a/src/module/models/gtpy_completermodel.h
+++ b/src/module/models/gtpy_completermodel.h
@@ -48,7 +48,7 @@ public:
      * @brief Sets the data to the model.
      * @param found Found completions.
      */
-    void setFound(const QMap<QString, GtpyFunction>& found);
+    void setFound(const QMultiMap<QString, GtpyFunction>& found);
 
     /**
      * @brief Returns the completion for the given index.
@@ -80,7 +80,7 @@ public:
 
 private:
     /// Found Completions
-    QMap<QString, GtpyFunction> m_found;
+    QMultiMap<QString, GtpyFunction> m_found;
 };
 
 #endif // GTPY_COMPLETERMODEL_H

--- a/src/module/models/gtpy_taskstylemodel.cpp
+++ b/src/module/models/gtpy_taskstylemodel.cpp
@@ -152,7 +152,7 @@ GtpyTaskStyleModel::flags(const QModelIndex& index) const
 {
     if (!index.isValid())
     {
-        return 0;
+        return {};
     }
 
     // collect default flags

--- a/src/module/utilities/gtpy_codegen.cpp
+++ b/src/module/utilities/gtpy_codegen.cpp
@@ -224,17 +224,17 @@ gtpy::codegen::pyIdentifier(const QString& str)
 
         // if the match is not at the start of the string and there is not
         // already an underscore before the match, prepend an underscore
-        if (startPos > 0 && ident.at(startPos - 1) != "_")
+        if (startPos > 0 && ident.at(startPos - 1) != '_')
         {
-            matchedStr.prepend("_");
+            matchedStr.prepend('_');
         }
 
         // if the match is not at the end of the string and it consists of
         // more than one letter, append an underscore
         if (!singleLetter && endPos < ident.length() &&
-            ident.at(endPos) != "_")
+            ident.at(endPos) != '_')
         {
-            matchedStr.append("_");
+            matchedStr.append('_');
         }
 
         ident.replace(startPos, endPos - startPos, matchedStr);

--- a/src/module/utilities/gtpy_contextmanager.cpp
+++ b/src/module/utilities/gtpy_contextmanager.cpp
@@ -925,7 +925,6 @@ GtpyContextManager::context(int contextId)
 }
 
 
-#ifdef PY3K
 PyPPObject
 GtpyContextManager::initExtensionModule(const QString& moduleName,
                                         PyModuleDef* def)
@@ -955,24 +954,7 @@ GtpyContextManager::initExtensionModule(const QString& moduleName,
 
     return myMod;
 }
-#else
-PyPPObject
-GtpyContextManager::initExtensionModule(const QString& moduleName,
-                                        PyMethodDef* methods)
-{
-    GTPY_GIL_SCOPE
 
-            QByteArray name = moduleName.toUtf8();
-    PyObject* myMod = nullptr;
-
-    myMod = Py_InitModule(name.constData(), methods);
-    Py_INCREF(myMod);
-
-    modulenameToBuiltins(moduleName);
-
-    return PyPPObject::NewRef(myMod);
-}
-#endif
 
 void
 GtpyContextManager::modulenameToBuiltins(QString name)
@@ -1013,13 +995,8 @@ void
 GtpyContextManager::initCalculatorsModule()
 {
     GTPY_GIL_SCOPE
-#ifdef PY3K
     initExtensionModule(gtpy::code::modules::GT_CALCULATORS,
                         &GtpyCalculatorsModule::GtpyCalculators_Module);
-#else
-    initExtensionModule(gtpy::code::modules::GT_CALCULATORS,
-                        GtpyCalculatorsModule::GtpyCalculatorsModule_StaticMethods);
-#endif
     GtpyCalculatorsModule::createCalcConstructors();
 }
 
@@ -1028,13 +1005,8 @@ GtpyContextManager::initLoggingModuleC()
 {
     GTPY_GIL_SCOPE
 
-#ifdef PY3K
     initExtensionModule(gtpy::code::modules::GT_LOGGING,
                         &GtpyLoggingModule::GtpyLogging_Module);
-#else
-    initExtensionModule(gtpy::code::modules::GT_LOGGING,
-                        GtpyLoggingModule::GtpyLoggingModule_StaticMethods);
-#endif
 }
 
 void
@@ -1095,14 +1067,9 @@ GtpyContextManager::initWrapperModule()
 {
     GTPY_GIL_SCOPE
 
-#ifdef PY3K
     auto mod = initExtensionModule(
         gtpy::code::modules::GT_OBJECT_WRAPPER_MODULE,
         &GtpyExtendedWrapperModule::GtpyExtendedWrapper_Module);
-#else
-    auto mod = initExtensionModule(
-        gtpy::code::modules::GT_OBJECT_WRAPPER_MODULE, nullptr);
-#endif
 
     auto wrapperType = PyPPObject::NewRef(
         (PyObject*)&GtpyExtendedWrapperModule::GtpyExtendedWrapper_Type);
@@ -1724,7 +1691,7 @@ GtpyContextManager::setImportableModulesCompletions(int contextId)
 
     foreach (QString name, modules)
     {
-        if (name.startsWith(name.startsWith(QStringLiteral("_"))))
+        if (name.startsWith(QStringLiteral("_")))
         {
             continue;
         }

--- a/src/module/utilities/gtpy_contextmanager.h
+++ b/src/module/utilities/gtpy_contextmanager.h
@@ -409,8 +409,6 @@ private:
      */
     bool createCustomModule(const QString& moduleName, const QString& code);
 
-
-#ifdef PY3K
     /**
      * @brief Initializes the extension module defined in def and adds it to
      * the built-in modules of Python. The new module is named after moduleName.
@@ -419,18 +417,6 @@ private:
      * @return A new reference of the extension module.
      */
     PyPPObject initExtensionModule(const QString& moduleName, PyModuleDef* def);
-#else
-    /**
-     * @brief Initializes the extension module and assigns it the static
-     * methods defined in methods. The new module is added to the built-in
-     * modules of Python and is named after moduleName.
-     * @param moduleName The name of the extension module.
-     * @param methods Definition of the static methods.
-     * @return A new reference of the extension module.
-     */
-    PyPPObject initExtensionModule(const QString& moduleName,
-                                   PyMethodDef* methods);
-#endif
 
     /**
      * @brief Adds the given name to the list of built-in modules in Python.

--- a/src/module/utilities/gtpy_convert.h
+++ b/src/module/utilities/gtpy_convert.h
@@ -11,7 +11,7 @@
 #ifndef GTPYCONVERT_H
 #define GTPYCONVERT_H
 
-#include "gt_globals.h"
+#include <gt_version.h>
 
 #include <Python.h>
 #include "gtpypp.h"

--- a/src/module/utilities/gtpy_regexp.cpp
+++ b/src/module/utilities/gtpy_regexp.cpp
@@ -10,10 +10,10 @@
 
 #include "gtpy_regexp.h"
 
-QRegExp
+QRegularExpression
 gtpy::re::exceptLettersAndNumbers()
 {
-    return QRegExp{"[^A-Za-z0-9]+"};
+    return QRegularExpression{"[^A-Za-z0-9]+"};
 }
 
 

--- a/src/module/utilities/gtpy_regexp.h
+++ b/src/module/utilities/gtpy_regexp.h
@@ -11,7 +11,6 @@
 #ifndef GTPYREGEXP_H
 #define GTPYREGEXP_H
 
-#include <QRegExp>
 #include <QRegularExpression>
 
 /**
@@ -26,7 +25,7 @@ namespace re
  * @brief Everything except letters and numbers.
  * @return Returns a QRegExp instance.
  */
-QRegExp exceptLettersAndNumbers();
+QRegularExpression exceptLettersAndNumbers();
 
 /**
  * @brief Returns a regular expression that matches valid Python identifiers.

--- a/src/module/utilities/pythonextensions/gtpy_calculatorsmodule.cpp
+++ b/src/module/utilities/pythonextensions/gtpy_calculatorsmodule.cpp
@@ -146,9 +146,9 @@ calcClassName(GtpyCreateCalculator* func)
 
     if (func->m_calcClassName)
     {
-        if (PyString_Check(func->m_calcClassName))
+        if (PyUnicode_Check(func->m_calcClassName))
         {
-            className = PyString_AsString(func->m_calcClassName);
+            className = PyUnicode_AsUTF8(func->m_calcClassName);
         }
     }
 

--- a/src/module/utilities/pythonextensions/gtpy_calculatorsmodule.h
+++ b/src/module/utilities/pythonextensions/gtpy_calculatorsmodule.h
@@ -49,7 +49,6 @@ GtpyCalculatorsModule_StaticMethods[] =
 
 void createCalcConstructors();
 
-#ifdef PY3K
 static PyModuleDef
 GtpyCalculators_Module =
 {
@@ -63,7 +62,6 @@ GtpyCalculators_Module =
     NULL,
     NULL
 };
-#endif
 
 }
 

--- a/src/module/utilities/pythonextensions/gtpy_createhelperfunction.cpp
+++ b/src/module/utilities/pythonextensions/gtpy_createhelperfunction.cpp
@@ -52,7 +52,7 @@ GtpyCreateHelperFunction_Call(PyObject* func, PyObject* args_py,
     auto args = PyPPObject::Borrow(args_py);
     Py_ssize_t argc = PyPPTuple_Size(args);
 
-    if (!f->m_helperName || !PyString_Check(f->m_helperName))
+    if (!f->m_helperName || !PyUnicode_Check(f->m_helperName))
     {
         QString error = "GtpyCreateHelperFunction is invalid!";
 
@@ -61,7 +61,7 @@ GtpyCreateHelperFunction_Call(PyObject* func, PyObject* args_py,
         return nullptr;
     }
 
-    QString helperName = QString(PyString_AsString(f->m_helperName));
+    QString helperName = QString(PyUnicode_AsUTF8(f->m_helperName));
 
     if (argc == 1)
     {

--- a/src/module/utilities/pythonextensions/gtpy_extendedwrapper.cpp
+++ b/src/module/utilities/pythonextensions/gtpy_extendedwrapper.cpp
@@ -22,12 +22,14 @@
 #include "gtpy_extendedwrapper.h"
 #include "gtpypp.h"
 
+#include <QRegularExpression>
+
 using namespace GtpyExtendedWrapperModule;
 
 static QString
 pyValidGtPropertyId(QString id)
 {
-    return id.replace(QRegExp("[^A-Za-z0-9]+"), "");
+    return id.replace(QRegularExpression("[^A-Za-z0-9]+"), "");
 }
 
 static QString
@@ -236,7 +238,7 @@ GtpyExtendedWrapper_methods[] =
 static int
 GtpyExtendedWrapper_setattro(PyObject* obj, PyObject* name, PyObject* value)
 {
-    QString strName = QString(PyString_AsString(name));
+    QString strName = QString(PyUnicode_AsUTF8(name));
 
     if (strName.isEmpty())
     {
@@ -336,13 +338,13 @@ GtpyExtendedWrapper_getattro(PyObject* obj, PyObject* name)
     }
 
     // Check if the given name is a string object
-    if (!PyString_Check(name))
+    if (!PyUnicode_Check(name))
     {
         PyErr_SetString(PyExc_AttributeError, "invalid attribute name");
         return nullptr;
     }
 
-    QString strName{PyString_AsString(name)};
+    QString strName{PyUnicode_AsUTF8(name)};
 
     if(strName.isEmpty())
     {
@@ -541,9 +543,6 @@ GtpyExtendedWrapper_as_number =
     0,      /* nb_add */
     0,      /* nb_subtract */
     0,      /* nb_multiply */
-#ifndef PY3K
-    0,      /* nb_divide */
-#endif
     0,      /* nb_remainder */
     0,      /* nb_divmod */
     0,      /* nb_power */
@@ -557,22 +556,12 @@ GtpyExtendedWrapper_as_number =
     0,    /* nb_and */
     0,    /* nb_xor */
     0,    /* nb_or */
-#ifndef PY3K
-    0,      /* nb_coerce */
-#endif
     0,      /* nb_int */
     0,      /* nb_long  / nb_reserved in Py3K */
     0,      /* nb_float */
-#ifndef PY3K
-    0,      /* nb_oct */
-    0,      /* nb_hex */
-#endif
     0,      /* nb_inplace_add */
     0,      /* nb_inplace_subtract */
     0,      /* nb_inplace_multiply */
-#ifndef PY3K
-    0,      /* nb_inplace_divide */
-#endif
     0,      /* nb_inplace_remainder */
     0,      /* nb_inplace_power */
     0,      /* nb_inplace_lshift */
@@ -584,9 +573,7 @@ GtpyExtendedWrapper_as_number =
     0,      /* nb_true_divide */
     0,      /* nb_inplace_floor_divide */
     0,      /* nb_inplace_true_divide */
-#ifdef PY3K
     0,      /* nb_index in Py3K */
-#endif
 };
 
 PyTypeObject
@@ -612,9 +599,6 @@ GtpyExtendedWrapperModule::GtpyExtendedWrapper_Type =
     GtpyExtendedWrapper_setattro, /*tp_setattro*/
     0,                            /*tp_as_buffer*/
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE
-#ifndef PY3K
-    | Py_TPFLAGS_CHECKTYPES
-#endif
     , /*tp_flags*/
     "GtpyExtendedWrapper object", /* tp_doc */
     0, /* tp_traverse */
@@ -623,11 +607,7 @@ GtpyExtendedWrapperModule::GtpyExtendedWrapper_Type =
     0, /* tp_weaklistoffset */
     0, /* tp_iter */
     0, /* tp_iternext */
-#ifdef PY3K
-    GtpyExtendedWrapper_methods,
-#else
     GtpyExtendedWrapper_methods, /* tp_methods */
-#endif
     0, /* tp_members */
     0, /* tp_getset */
     0, /* tp_base */

--- a/src/module/utilities/pythonextensions/gtpy_extendedwrapper.h
+++ b/src/module/utilities/pythonextensions/gtpy_extendedwrapper.h
@@ -37,7 +37,6 @@ struct GtpyExtendedWrapper
     QObject* getObject() const;
 };
 
-#ifdef PY3K
 static PyModuleDef
 GtpyExtendedWrapper_Module =
 {
@@ -51,7 +50,6 @@ GtpyExtendedWrapper_Module =
     NULL,
     NULL
 };
-#endif
 }
 
 namespace GtpyCustomization

--- a/src/module/utilities/pythonextensions/gtpy_loggingmodule.cpp
+++ b/src/module/utilities/pythonextensions/gtpy_loggingmodule.cpp
@@ -264,7 +264,7 @@ GtpyPyLogger_lshift(PyObject* self, PyObject* arg)
     const auto* msg = PyPPUnicode_AsUTF8(pyMsg);
     if (!msg) return nullptr;
 
-    auto logLevel = static_cast<LogLevel>(PyInt_AsLong(logger->m_logLevel));
+    auto logLevel = static_cast<LogLevel>(PyLong_AsLong(logger->m_logLevel));
 
     printToConsols(logLevel, msg);
 
@@ -277,9 +277,6 @@ static PyNumberMethods
         0,      /* nb_add */
         0,      /* nb_subtract */
         0,      /* nb_multiply */
-#ifndef PY3K
-        0,      /* nb_divide */
-#endif
         0,      /* nb_remainder */
         0,      /* nb_divmod */
         0,      /* nb_power */
@@ -293,22 +290,12 @@ static PyNumberMethods
         0,    /* nb_and */
         0,    /* nb_xor */
         0,    /* nb_or */
-#ifndef PY3K
-        0,      /* nb_coerce */
-#endif
         0,      /* nb_int */
         0,      /* nb_long  / nb_reserved in Py3K */
         0,      /* nb_float */
-#ifndef PY3K
-        0,      /* nb_oct */
-        0,      /* nb_hex */
-#endif
         0,      /* nb_inplace_add */
         0,      /* nb_inplace_subtract */
         0,      /* nb_inplace_multiply */
-#ifndef PY3K
-        0,      /* nb_inplace_divide */
-#endif
         0,      /* nb_inplace_remainder */
         0,      /* nb_inplace_power */
         0,      /* nb_inplace_lshift */
@@ -320,9 +307,7 @@ static PyNumberMethods
         0,      /* nb_true_divide */
         0,      /* nb_inplace_floor_divide */
         0,      /* nb_inplace_true_divide */
-#ifdef PY3K
-        0,      /* nb_index in Py3K */
-#endif
+        0,      /* nb_index */
 };
 
 PyTypeObject
@@ -348,11 +333,7 @@ PyTypeObject
     0,  /*tp_setattro*/
     0,  /*tp_as_buffer*/
            Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE /*tp_flags*/
-#ifndef PY3K
-           | Py_TPFLAGS_CHECKTYPES,
-#else
     ,
-#endif
     "GtpyPyLogger doc",/* tp_doc */
     0,  /* tp_traverse */
     0,  /* tp_clear */

--- a/src/module/utilities/pythonextensions/gtpy_loggingmodule.h
+++ b/src/module/utilities/pythonextensions/gtpy_loggingmodule.h
@@ -105,7 +105,6 @@ GtpyLoggingModule_StaticMethods[] =
 };
 
 
-#ifdef PY3K
 static PyModuleDef
 GtpyLogging_Module =
 {
@@ -119,7 +118,6 @@ GtpyLogging_Module =
     NULL,
     NULL
 };
-#endif
 
 }
 

--- a/src/module/utilities/pythonextensions/gtpy_propertysetter.cpp
+++ b/src/module/utilities/pythonextensions/gtpy_propertysetter.cpp
@@ -53,14 +53,14 @@ meth_repr(GtpyPropertySetterObject* f)
     if (f->m_self->ob_type == &GtpyExtendedWrapper_Type)
     {
         QString repr = "<Function to set " + QString(
-                           PyString_AsString(f->m_propId)) +
+                           PyUnicode_AsUTF8(f->m_propId)) +
                        " value>";
 
-        return PyString_FromFormat(repr.toStdString().c_str());
+        return PyUnicode_FromFormat(repr.toStdString().c_str());
     }
     else
     {
-        return PyString_FromFormat("<invalid function>");
+        return PyUnicode_FromFormat("<invalid function>");
     }
 }
 
@@ -89,7 +89,7 @@ GtpyPropertySetter_Call(PyObject* func, PyObject* args,
 
     Py_ssize_t argc = PyTuple_Size(args);
 
-    QString propId = QString(PyString_AsString(f->m_propId));
+    QString propId = QString(PyUnicode_AsUTF8(f->m_propId));
 
     if (argc != 1)
     {
@@ -252,11 +252,7 @@ GtpyPropertySetter_Type =
     0,          /* tp_print */
     0,          /* tp_getattr */
     0,          /* tp_setattr */
-#ifdef PY3K
     0,
-#else
-    (cmpfunc)meth_compare,      /* tp_compare */
-#endif
     (reprfunc)meth_repr,      /* tp_repr */
     0,          /* tp_as_number */
     0,          /* tp_as_sequence */

--- a/src/module/utilities/pythonextensions/gtpy_stdout.cpp
+++ b/src/module/utilities/pythonextensions/gtpy_stdout.cpp
@@ -83,22 +83,7 @@ GtpyStdOutRedirect_write(PyObject* self, PyObject* args)
 
             if (PyPPUnicode_Check(obj))
             {
-#ifdef PY3K
                 message = PyPPString_AsQString(obj);
-#else
-                PyObject* tmp = PyUnicode_AsUTF8String(obj.get());
-
-                if (tmp)
-                {
-                    message = QString::fromUtf8(PyString_AS_STRING(tmp));
-                    Py_DECREF(tmp);
-                }
-                else
-                {
-                    return NULL;
-                }
-
-#endif
             }
             else
             {

--- a/src/module/widgets/gtpy_console.cpp
+++ b/src/module/widgets/gtpy_console.cpp
@@ -82,7 +82,12 @@ GtpyConsole::GtpyConsole(int contextId,
 
     const int tabStop = 4;
     QFontMetrics metrics(font);
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    setTabStopDistance(tabStop * metrics.horizontalAdvance(' '));
+#else
     setTabStopWidth(tabStop * metrics.width(' '));
+#endif
 }
 
 void

--- a/src/module/widgets/gtpy_scripteditor.cpp
+++ b/src/module/widgets/gtpy_scripteditor.cpp
@@ -138,16 +138,24 @@ GtpyScriptEditor::wheelEvent(QWheelEvent* event)
 {
     if (event->modifiers() == Qt::ControlModifier && !isReadOnly())
     {
-        if (event->delta() > 0)
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        const int dy = event->angleDelta().y();
+#else
+        const int dy = event->delta();
+#endif
+
+        if (dy > 0)
         {
             zoomIn(2);
         }
-        else
+        else if (dy < 0)
         {
             zoomOut(2);
         }
 
         setTabSize(m_tabSize);
+
+        event->accept();
     }
     else
     {
@@ -293,10 +301,10 @@ GtpyScriptEditor::replaceBlockHeaders(const QString& oldHeader,
 }
 
 void
-GtpyScriptEditor::searchAndReplace(const QRegExp& searchRegExp, const
+GtpyScriptEditor::searchAndReplace(const QRegularExpression& searchRegExp, const
                                    QString& replaceBy, bool all)
 {
-    if (searchRegExp.isEmpty() || !searchRegExp.isValid())
+    if (!searchRegExp.isValid() || searchRegExp.pattern().isEmpty())
     {
         return;
     }
@@ -1217,7 +1225,7 @@ GtpyScriptEditor::isSelectionIndentable()
     QString selection = cursor.selectedText();
 
     QStringList lines = selection.split(QChar::ParagraphSeparator,
-                                        QString::SkipEmptyParts);
+                                        Qt::SkipEmptyParts);
 
     int count = lines.count();
 

--- a/src/module/widgets/gtpy_scripteditor.h
+++ b/src/module/widgets/gtpy_scripteditor.h
@@ -16,6 +16,8 @@
 #include "gt_calculator.h"
 #include "gt_codeeditor.h"
 
+#include <QRegularExpression>
+
 class GtpyCompleter;
 
 /**
@@ -91,7 +93,7 @@ public:
      * @param all If it is true, all strings in the document will be replaced.
      * Otherwise it only replaces the first one found.
      */
-    void searchAndReplace(const QRegExp& searchRegExp, const QString& replaceBy,
+    void searchAndReplace(const QRegularExpression& searchRegExp, const QString& replaceBy,
                           bool all = true);
     /**
      * @brief Searchs for the given string searchFor and replaces it

--- a/src/module/widgets/gtpy_scripteditorwidget.cpp
+++ b/src/module/widgets/gtpy_scripteditorwidget.cpp
@@ -47,7 +47,6 @@ GtpyScriptEditorWidget::GtpyScriptEditorWidget(int contextId, QWidget* parent) :
     /// top layout
     auto* topLayout = new QHBoxLayout();
     topLayout->setSpacing(0);
-    topLayout->setMargin(0);
     topLayout->setContentsMargins(0, 0, 0, 0);
 
     m_pimpl->m_undoButton = new QPushButton;

--- a/src/module/widgets/gtpy_taskdelegate.cpp
+++ b/src/module/widgets/gtpy_taskdelegate.cpp
@@ -29,12 +29,12 @@ GtpyTaskDelegate::createEditor(QWidget* parent,
     QLineEdit* lineEdit = new QLineEdit(parent);
 
 #if GT_VERSION < 0x020000
-    QRegExp regExp = GtRegExp::onlyLettersAndNumbersAndSpace();
+    QRegExp onlyLettersAndNumbersAndSpaceExp = GtRegExp::onlyLettersAndNumbersAndSpace();
 #else
-    QRegExp regExp = gt::re::onlyLettersAndNumbersAndSpace();
+    static QRegularExpression onlyLettersAndNumbersAndSpaceExp("[A-Za-z0-9\\_\\-\\[\\]\\s\\␣]+");
 #endif
 
-    QValidator* validator = new QRegExpValidator(regExp, this->parent());;
+    QValidator* validator = new QRegularExpressionValidator(onlyLettersAndNumbersAndSpaceExp, this->parent());;
 
     lineEdit->setValidator(validator);
 

--- a/src/module/wizards/gtpy_abstractscriptingwizardpage.cpp
+++ b/src/module/wizards/gtpy_abstractscriptingwizardpage.cpp
@@ -101,7 +101,6 @@ GtpyAbstractScriptingWizardPage::GtpyAbstractScriptingWizardPage(
     QHBoxLayout* separatorLay = new QHBoxLayout(this);
 
     separatorLay->setSpacing(0);
-    separatorLay->setMargin(0);
     separatorLay->setContentsMargins(0, 0, 0, 0);
 
     QLabel* label = new QLabel("Output Console:", this);
@@ -542,7 +541,7 @@ GtpyAbstractScriptingWizardPage::replaceBlockHeaders(const QString& oldHeader,
 
 void
 GtpyAbstractScriptingWizardPage::searchAndReplaceEditorText(
-    const QRegExp& searchFor, const QString& replaceBy, bool all)
+    const QRegularExpression& searchFor, const QString& replaceBy, bool all)
 {
     if (!m_editor)
     {
@@ -586,28 +585,9 @@ GtpyAbstractScriptingWizardPage::setConsoleVisible(bool visible)
 QString
 GtpyAbstractScriptingWizardPage::indentation(const QString& codeLine) const
 {
-    QString indent;
-    QRegExp spacesRegExp("^ +\t*");
-    QRegExp tabRegExp("^\t+ *");
-    QRegExp regExp;
-
-    if (codeLine.contains(spacesRegExp))
-    {
-        regExp = spacesRegExp;
-    }
-    else if (codeLine.contains(tabRegExp))
-    {
-        regExp = tabRegExp;
-    }
-
-    int pos = regExp.indexIn(codeLine);
-
-    if (pos > -1)
-    {
-        indent = regExp.cap(0);
-    }
-
-    return indent;
+    static const QRegularExpression leadingIndent(R"(^[ \t]+)");
+    const QRegularExpressionMatch match = leadingIndent.match(codeLine);
+    return match.hasMatch() ? match.captured(0) : QString{};
 }
 
 void

--- a/src/module/wizards/gtpy_abstractscriptingwizardpage.h
+++ b/src/module/wizards/gtpy_abstractscriptingwizardpage.h
@@ -140,7 +140,7 @@ protected:
      * @param all If it is true, all founds in the document will be replaced.
      * Otherwise it replaces only the first one found.
      */
-    void searchAndReplaceEditorText(const QRegExp& searchFor,
+    void searchAndReplaceEditorText(const QRegularExpression& searchFor,
                                     const QString& replaceBy, bool all);
 
     /**

--- a/src/module/wizards/python_task/gtpy_taskwizardpage.cpp
+++ b/src/module/wizards/python_task/gtpy_taskwizardpage.cpp
@@ -78,7 +78,6 @@ GtpyTaskWizardPage::GtpyTaskWizardPage() :
     QVBoxLayout* treeViewLay = new QVBoxLayout;
 
     treeViewLay->setSpacing(1);
-    treeViewLay->setMargin(0);
     treeViewLay->setContentsMargins(0, 0, 0, 0);
 
     treeViewLay->addWidget(addElementButton);
@@ -690,7 +689,7 @@ GtpyTaskWizardPage::onProcessComponentRenamed(QString const& className,
     QString pattern = "(" + className + "\\( *\"" + oldName + "\" *\\))";
     QString replace = className + "(\"" + newName + "\")";
 
-    searchAndReplaceEditorText(QRegExp(pattern), replace, true);
+    searchAndReplaceEditorText(QRegularExpression(pattern), replace, true);
 }
 
 void

--- a/src/setup_module/gtps_pythonpreferencepage.cpp
+++ b/src/setup_module/gtps_pythonpreferencepage.cpp
@@ -172,7 +172,7 @@ void
 GtPythonPreferencePage::setStatusTextColor(const QColor& color)
 {
     auto palette = ui->lbPythonStatus->palette();
-    palette.setColor(QPalette::Foreground, color);
+    palette.setColor(QPalette::WindowText, color);
     ui->lbPythonStatus->setPalette(palette);
 }
 

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -3,12 +3,12 @@
 
 project(GTlabPython-UnitTests)
 
-if (NOT TARGET Qt5::Core)
-    find_package(Qt5 REQUIRED COMPONENTS Core)
-endif()
-
-
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+
+if (NOT TARGET Qt5::Core AND NOT TARGET Qt6::Core)
+    include(RequireQt)
+    require_qt(COMPONENTS Core)
+endif()
 
 if (NOT TARGET gtest)
     include(AddGoogleTest)
@@ -27,7 +27,7 @@ target_compile_definitions(GTlabPythonUnitTest
     PRIVATE GT_MODULE_ID="Python Unit Tests"
 )
 
-target_link_libraries(GTlabPythonUnitTest PRIVATE GTlab::Core GTlab::Python gtest Qt5::Core)
+target_link_libraries(GTlabPythonUnitTest PRIVATE GTlab::Core GTlab::Python gtest Qt${QT_VERSION_MAJOR}::Core)
 
 include(GoogleTest)
 gtest_discover_tests(GTlabPythonUnitTest TEST_PREFIX "PythonModule." DISCOVERY_MODE PRE_TEST)

--- a/tests/unittests/cmake/RequireQt.cmake
+++ b/tests/unittests/cmake/RequireQt.cmake
@@ -96,5 +96,4 @@ function(require_qt)
     # actually find qt
     find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS ${RQT_COMPONENTS})
     set (QT_VERSION_MAJOR ${QT_VERSION_MAJOR} PARENT_SCOPE)
-    set (QT_VERSION_MINOR ${Qt${QT_VERSION_MAJOR}_VERSION_MINOR} PARENT_SCOPE)
 endfunction()

--- a/thirdparty/pythonqt/CMakeLists.txt
+++ b/thirdparty/pythonqt/CMakeLists.txt
@@ -8,9 +8,15 @@ cmake_minimum_required(VERSION 3.15)
 
 project(PythonQt)
 
+set(PythonQT_VERSION Qt6.5)
+
 #----------------------------------------------------------------------------
-set(PythonQt_QT_VERSION 5)
-set(PythonQT_VERSION 3.4.2)
+set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR})
+
+include(RequireQt)
+require_qt(COMPONENTS Core Widgets Network OpenGL Sql Svg UiTools Xml)
+
+set(PythonQt_QT_VERSION ${QT_VERSION_MAJOR})
 
 set(CMAKE_AUTOMOC ON)
 
@@ -18,17 +24,12 @@ set(CMAKE_AUTOMOC ON)
 set(minimum_required_qt5_version "5.3.0")
 set(minimum_required_qt_version ${minimum_required_qt${PythonQt_QT_VERSION}_version})
 
-find_package(Qt5 ${minimum_required_qt_version} QUIET)
-set(QT_VERSION_MAJOR ${Qt5_VERSION_MAJOR})
-set(QT_VERSION_MINOR ${Qt5_VERSION_MINOR})
-
-
 # Download pythonqt source code
 include(FetchContent)
 FetchContent_Declare(
     pythonqt
-    GIT_REPOSITORY https://github.com/MeVisLab/pythonqt.git
-    GIT_TAG v${PythonQT_VERSION}
+    GIT_REPOSITORY https://github.com/dlr-gtlab/pythonqt.git
+    GIT_TAG ${PythonQT_VERSION}
 )
 
 if(NOT pythonqt_POPULATED)
@@ -162,7 +163,7 @@ endif()
 list(REMOVE_DUPLICATES qt_required_components)
 
 message(STATUS "${PROJECT_NAME}: Required Qt components [${qt_required_components}]")
-find_package(Qt5 ${minimum_required_qt_version} COMPONENTS ${qt_required_components} REQUIRED)
+require_qt(COMPONENTS ${qt_required_components})
 
 if(UNIX)
   find_package(OpenGL)
@@ -177,10 +178,13 @@ endif()
 
 set(generated_cpp_suffix_52 _50)
 set(generated_cpp_suffix_51 _50)
+set(generated_cpp_suffix_65 _65)
 
 set(generated_cpp_suffix "_${QT_VERSION_MAJOR}${QT_VERSION_MINOR}")
 if(DEFINED generated_cpp_suffix_${QT_VERSION_MAJOR}${QT_VERSION_MINOR})
   set(generated_cpp_suffix "${generated_cpp_suffix_${QT_VERSION_MAJOR}${QT_VERSION_MINOR}}")
+elseif("${QT_VERSION_MAJOR}.${QT_VERSION_MINOR}" VERSION_GREATER "6.4")
+  set(generated_cpp_suffix "_65")
 elseif("${QT_VERSION_MAJOR}.${QT_VERSION_MINOR}" VERSION_GREATER "5.10")
   set(generated_cpp_suffix "_511")
 elseif("${QT_VERSION_MAJOR}.${QT_VERSION_MINOR}" VERSION_GREATER "5.5")

--- a/thirdparty/pythonqt/CMakeLists.txt
+++ b/thirdparty/pythonqt/CMakeLists.txt
@@ -176,8 +176,7 @@ endif()
 # The variable "generated_cpp_suffix" allows to conditionnally compile the generated wrappers
 # associated with the Qt version being used.
 
-set(generated_cpp_suffix_52 _50)
-set(generated_cpp_suffix_51 _50)
+set(generated_cpp_suffix_515 _515)
 set(generated_cpp_suffix_65 _65)
 
 set(generated_cpp_suffix "_${QT_VERSION_MAJOR}${QT_VERSION_MINOR}")
@@ -185,12 +184,8 @@ if(DEFINED generated_cpp_suffix_${QT_VERSION_MAJOR}${QT_VERSION_MINOR})
   set(generated_cpp_suffix "${generated_cpp_suffix_${QT_VERSION_MAJOR}${QT_VERSION_MINOR}}")
 elseif("${QT_VERSION_MAJOR}.${QT_VERSION_MINOR}" VERSION_GREATER "6.4")
   set(generated_cpp_suffix "_65")
-elseif("${QT_VERSION_MAJOR}.${QT_VERSION_MINOR}" VERSION_GREATER "5.10")
-  set(generated_cpp_suffix "_511")
-elseif("${QT_VERSION_MAJOR}.${QT_VERSION_MINOR}" VERSION_GREATER "5.5")
-  set(generated_cpp_suffix "_56")
-elseif("${QT_VERSION_MAJOR}.${QT_VERSION_MINOR}" VERSION_GREATER "5.3")
-  set(generated_cpp_suffix "_54")
+elseif("${QT_VERSION_MAJOR}.${QT_VERSION_MINOR}" VERSION_GREATER "5.14")
+  set(generated_cpp_suffix "_515")
 endif()
 
 #-----------------------------------------------------------------------------

--- a/thirdparty/pythonqt/RequireQt.cmake
+++ b/thirdparty/pythonqt/RequireQt.cmake
@@ -1,0 +1,97 @@
+# ==============================================================================
+# require_qt(
+#   COMPONENTS <comp>...
+# )
+#
+# Summary:
+#   Locate and configure a single Qt major version (5 or 6) for the entire
+#   build and ensure the requested components are available.
+#
+# Behavior:
+#   - Uses Qt’s “dual version” pattern:
+#       find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS <components>)
+#       find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS <components>)
+#
+#   - On the first call, if QT_VERSION_MAJOR is NOT defined:
+#       * If Qt has already been found by the parent project
+#         (e.g. via find_package(QT ...) or find_package(Qt6/Qt5 ...)),
+#         QT_VERSION_MAJOR is taken from the existing Qt configuration or
+#         inferred from existing Qt6::*/Qt5::* targets.
+#       * Otherwise, require_qt() calls:
+#             find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS <components>)
+#         which sets QT_VERSION_MAJOR to 5 or 6 according to what CMake
+#         finds on the search path.
+#       * QT_VERSION_MAJOR is then cached so all subsequent calls reuse
+#         the same major version.
+#
+#   - On subsequent calls (QT_VERSION_MAJOR already defined):
+#       * require_qt() simply calls:
+#             find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS <components>)
+#         to make sure the requested modules for the chosen major are available.
+#
+# Guarantees:
+#   - All callers (core and modules) in a single build tree use the same Qt
+#     major version, as determined by the first successful Qt detection.
+#   - If the requested Qt components for that major cannot be found,
+#     configuration fails with an error.
+#
+# User control of the chosen Qt version:
+#   - Standard CMake mechanisms apply. The user can steer which Qt is found by:
+#       * Adjusting CMAKE_PREFIX_PATH / Qt installation order (preferred), or
+#       * Setting Qt5_DIR / Qt6_DIR to point at a specific Qt installation
+#
+# Notes:
+#   - This function does NOT create versionless Qt:: targets. Callers are
+#     expected to link against versioned targets, e.g.:
+#         Qt${QT_VERSION_MAJOR}::Core
+#         Qt${QT_VERSION_MAJOR}::Widgets
+#         Qt${QT_VERSION_MAJOR}::<OtherComponent>
+# ==============================================================================
+function(require_qt)
+    set(options)
+    set(oneValueArgs)
+    set(multiValueArgs COMPONENTS)
+    cmake_parse_arguments(RQT "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    if (NOT RQT_COMPONENTS)
+        message(FATAL_ERROR "require_qt() called without COMPONENTS")
+    endif()
+    
+    # --------------------------------------------------------
+    # 1. Decide QT_VERSION_MAJOR once
+    # --------------------------------------------------------
+    if (NOT DEFINED QT_VERSION_MAJOR)
+
+        # 1a) If user hinted a specific major via Qt6_DIR / Qt5_DIR, respect that
+        if (DEFINED Qt6_DIR AND NOT DEFINED Qt5_DIR)
+            set(QT_VERSION_MAJOR 6)
+        elseif (DEFINED Qt5_DIR AND NOT DEFINED Qt6_DIR)
+            set(QT_VERSION_MAJOR 5)
+
+        elseif (DEFINED Qt5_DIR AND DEFINED Qt6_DIR)
+            set(QT_VERSION_MAJOR 6)
+        else()
+            # 1b) No specific *_DIR hints: use the standard Qt dual-version pattern
+            #     This will honor QT_DIR, CMAKE_PREFIX_PATH, etc.
+            find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS ${RQT_COMPONENTS})
+        endif()
+
+        # One-time status message
+        if (NOT DEFINED GTLAB_QT_VERSION_REPORTED AND DEFINED QT_VERSION_MAJOR)
+            message(STATUS "GTlab: using Qt${QT_VERSION_MAJOR} for this build")
+            set(GTLAB_QT_VERSION_REPORTED TRUE CACHE INTERNAL
+                "Whether the selected Qt version has been reported")
+        endif()
+    endif()
+
+    if (NOT DEFINED QT_VERSION_MAJOR)
+        message(FATAL_ERROR
+            "require_qt(): QT_VERSION_MAJOR is still undefined after detection. "
+            "Check your Qt hints: QT_DIR, Qt5_DIR, Qt6_DIR, CMAKE_PREFIX_PATH.")
+    endif()
+
+    # actually find qt
+    find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS ${RQT_COMPONENTS})
+    set (QT_VERSION_MAJOR ${QT_VERSION_MAJOR} PARENT_SCOPE)
+    set (QT_VERSION_MINOR ${Qt${QT_VERSION_MAJOR}_VERSION_MINOR} PARENT_SCOPE)
+endfunction()


### PR DESCRIPTION
This is my first attempt for a Qt6 support.

This required many changes, most of them happed due to an upgrade of pythonqt itself.

The new pythonqt version does not provide
 - The PY3K define anymore
 - Wrapper functions to deprecated python API like PyString_AsString etc...
 
 Hence, I needed to replace these functions and I removed all Python2 code paths.