### PR TITLE
Fixed accessing task from other task groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    it returns only the modules that are part of the data model of the current project. - #630
  - Fixed a crash when creating a calculator with missing author information in a Python Task - #627
  - Fixed an issue where empty lines were printed to the Python console even when the evaluated script did not contain any print statements. - #622 
+ - Fixed accessing tasks from other task groups. This can be done via `findGtTask("groupname/taskname")` or `runProcess("groupname/taskname")`. - #639
 
 ## [1.8.0] - 2025-07-11
 

--- a/src/module/CMakeLists.txt
+++ b/src/module/CMakeLists.txt
@@ -63,6 +63,7 @@ set(HEADERS
     utilities/gtpy_regexp.h
     utilities/gtpy_scriptrunnable.h
     utilities/gtpy_utils.h
+    utilities/gtpy_taskapi.h
     utilities/gtpy_tempdir.h
     utilities/gtpy_transfer.h
     utilities/pythonextensions/gtpy_createhelperfunction.h
@@ -136,6 +137,7 @@ set(SOURCES
     utilities/gtpy_regexp.cpp
     utilities/gtpy_scriptrunnable.cpp
     utilities/gtpy_utils.cpp
+    utilities/gtpy_taskapi.cpp
     utilities/gtpy_tempdir.cpp
     utilities/gtpy_transfer.cpp
     utilities/pythonextensions/gtpy_calculatorsmodule.cpp

--- a/src/module/utilities/gtpy_decorator.cpp
+++ b/src/module/utilities/gtpy_decorator.cpp
@@ -37,6 +37,7 @@
 #include "gtpy_scriptcalculator.h"
 #include "gtpy_convert.h"
 #include "gtpy_threadscope.h"
+#include "gtpy_taskapi.h"
 
 #include "gtpy_decorator.h"
 
@@ -497,7 +498,8 @@ GtpyDecorator::runProcess(GtProject* pro, const QString& processId,
     qDebug() << "process run starts...      processId == " << processId;
     // run process
 
-    GtTask* process = pro->findProcess(processId);
+    auto spec = gtpy::parseTaskSpec(processId);
+    GtTask* process = gtpy::getTask(pro->processData(), spec);
 
     if (process == nullptr)
     {

--- a/src/module/utilities/gtpy_processdatadistributor.cpp
+++ b/src/module/utilities/gtpy_processdatadistributor.cpp
@@ -14,6 +14,7 @@
 #include "gt_task.h"
 
 #include "gtpy_processdatadistributor.h"
+#include "gtpy_taskapi.h"
 
 GtpyProcessDataDistributor::GtpyProcessDataDistributor(GtTask* pythonTask)
 {
@@ -30,34 +31,13 @@ GtpyProcessDataDistributor::taskElement(const QString& name)
         return nullptr;
     }
 
-#if GT_VERSION >= 0x020000
-    GtTaskGroup* group = data->taskGroup();
+    auto taskSpec = gtpy::parseTaskSpec(name);
+    GtTask* task = getTask(data, taskSpec);
 
-    if (!group)
-    {
-        return nullptr;
-    }
-
-    GtTask* task = group->findDirectChild<GtTask*>(name);
-#else
-    GtTask* task = data->findDirectChild<GtTask*>(name);
-#endif
     if (!task)
     {
         return task;
     }
-
-    //    QList<GtTask*> children = m_pythonTask->findDirectChildren<GtTask*>();
-
-    //    foreach (GtTask* child, children)
-    //    {
-    //        if(child->uuid() == task->uuid())
-    //        {
-    //            delete child;
-    //            child = nullptr;
-    //            break;
-    //        }
-    //    }
 
     task = qobject_cast<GtTask*>(task->clone());
 

--- a/src/module/utilities/gtpy_taskapi.cpp
+++ b/src/module/utilities/gtpy_taskapi.cpp
@@ -15,7 +15,7 @@ namespace gtpy
 {
 
 TaskSpec
-parseTaskSpec(const QString &spec)
+parseTaskSpec(const QString& spec)
 {
     TaskSpec out;
     const int slash = spec.indexOf('/');
@@ -28,8 +28,8 @@ parseTaskSpec(const QString &spec)
     }
 
     out.hasExplicitGroup = true;
-    out.groupId = spec.left(slash).trimmed();
-    out.taskId = spec.mid(slash + 1).trimmed();
+    out.groupId = spec.left(slash);
+    out.taskId = spec.mid(slash + 1);
 
     return out;
 }
@@ -43,6 +43,8 @@ parseTaskSpec(const QString &spec)
 bool
 initTaskGroup(GtTaskGroup* group, GtTaskGroup::SCOPE scope)
 {
+    if (!group) return false;
+
     if (group->isInitialized()) return true;
 
     if (!gtApp || !gtApp->currentProject() || !group) return false;
@@ -74,8 +76,10 @@ initTaskGroup(GtTaskGroup* group, GtTaskGroup::SCOPE scope)
 
 #if GT_VERSION >= 0x020000
 GtTaskGroup*
-getTaskGroup(GtProcessData *data, TaskSpec spec)
+getTaskGroup(GtProcessData* data, TaskSpec spec)
 {
+    if  (!data) return nullptr;
+
     GtTaskGroup* group = nullptr;
 
     auto& groupName = spec.groupId;
@@ -83,17 +87,14 @@ getTaskGroup(GtProcessData *data, TaskSpec spec)
     if (groupName.isEmpty()) return data->taskGroup();
 
     GtTaskGroup::SCOPE scope = GtTaskGroup::UNDEFINED;
-    QString scopeKey = "";
 
     if (data->customGroupIds().contains(groupName))
     {
         scope = GtTaskGroup::CUSTOM;
-        scopeKey = "_custom";
     }
     else if(data->userGroupIds().contains(groupName))
     {
         scope = GtTaskGroup::USER;
-        scopeKey = "_user";
     }
 
     if (scope == GtTaskGroup::UNDEFINED)
@@ -101,7 +102,8 @@ getTaskGroup(GtProcessData *data, TaskSpec spec)
         return nullptr;
     }
 
-    auto* scopeElement = data->findDirectChild<GtObjectGroup*>(scopeKey);
+    auto* scopeElement = data->findDirectChild<GtObjectGroup*>(
+        GtTaskGroup::scopeId(scope));
 
     if (!scopeElement)
     {
@@ -122,8 +124,10 @@ getTaskGroup(GtProcessData *data, TaskSpec spec)
 #endif
 
 GtTask*
-getTask(GtProcessData *data, TaskSpec spec)
+getTask(GtProcessData* data, TaskSpec spec)
 {
+    if (!data) return nullptr;
+
 #if GT_VERSION >= 0x020000
     GtTaskGroup* group = getTaskGroup(data, spec);
 

--- a/src/module/utilities/gtpy_taskapi.cpp
+++ b/src/module/utilities/gtpy_taskapi.cpp
@@ -1,0 +1,141 @@
+/* GTlab - Gas Turbine laboratory
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: 2026 German Aerospace Center (DLR)
+ */
+
+#include "gtpy_taskapi.h"
+
+#include <gt_application.h>
+#include <gt_project.h>
+
+#include <QThread>
+
+namespace gtpy
+{
+
+TaskSpec
+parseTaskSpec(const QString &spec)
+{
+    TaskSpec out;
+    const int slash = spec.indexOf('/');
+
+    if (slash < 0)
+    {
+        out.taskId = spec;
+
+        return out;
+    }
+
+    out.hasExplicitGroup = true;
+    out.groupId = spec.left(slash).trimmed();
+    out.taskId = spec.mid(slash + 1).trimmed();
+
+    return out;
+}
+
+/**
+ * @brief Tries to initialize a task group
+ * @param group
+ * @param scope
+ * @return
+ */
+bool
+initTaskGroup(GtTaskGroup* group, GtTaskGroup::SCOPE scope)
+{
+    if (group->isInitialized()) return true;
+
+    if (!gtApp || !gtApp->currentProject() || !group) return false;
+
+    auto initGroupImpl  = [group, scope]() {
+        group->read(gtApp->currentProject()->path(), scope);
+    };
+
+    // task group intialization must be done in the main thread
+    if (QThread::currentThread() == gtApp->thread())
+    {
+        initGroupImpl();
+    }
+    else
+    {
+        QMetaObject::invokeMethod(gtApp, initGroupImpl,
+                                  Qt::BlockingQueuedConnection);
+    }
+
+    if (!group->isInitialized())
+    {
+        gtError() << QObject::tr("Error initializing task group '%1'")
+            .arg(group->objectName());
+        return false;
+    }
+
+    return true;
+}
+
+#if GT_VERSION >= 0x020000
+GtTaskGroup*
+getTaskGroup(GtProcessData *data, TaskSpec spec)
+{
+    GtTaskGroup* group = nullptr;
+
+    auto& groupName = spec.groupId;
+
+    if (groupName.isEmpty()) return data->taskGroup();
+
+    GtTaskGroup::SCOPE scope = GtTaskGroup::UNDEFINED;
+    QString scopeKey = "";
+
+    if (data->customGroupIds().contains(groupName))
+    {
+        scope = GtTaskGroup::CUSTOM;
+        scopeKey = "_custom";
+    }
+    else if(data->userGroupIds().contains(groupName))
+    {
+        scope = GtTaskGroup::USER;
+        scopeKey = "_user";
+    }
+
+    if (scope == GtTaskGroup::UNDEFINED)
+    {
+        return nullptr;
+    }
+
+    auto* scopeElement = data->findDirectChild<GtObjectGroup*>(scopeKey);
+
+    if (!scopeElement)
+    {
+        return nullptr;
+    }
+
+    group = scopeElement->findDirectChild<GtTaskGroup*>(groupName);
+
+    if (!group)
+    {
+        return nullptr;
+    }
+
+    if (!initTaskGroup(group, scope)) return nullptr;
+
+    return group;
+}
+#endif
+
+GtTask*
+getTask(GtProcessData *data, TaskSpec spec)
+{
+#if GT_VERSION >= 0x020000
+    GtTaskGroup* group = getTaskGroup(data, spec);
+
+    if (!group)
+    {
+        return nullptr;
+    }
+
+    return group->findDirectChild<GtTask*>(spec.taskId);
+#else
+    return data->findDirectChild<GtTask*>(spec.taskId);
+#endif
+}
+
+} // namespace gtpy

--- a/src/module/utilities/gtpy_taskapi.h
+++ b/src/module/utilities/gtpy_taskapi.h
@@ -1,0 +1,46 @@
+/* GTlab - Gas Turbine laboratory
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: 2026 German Aerospace Center (DLR)
+ */
+
+#ifndef GTPY_TASKAPI_H
+#define GTPY_TASKAPI_H
+
+#include <gt_task.h>
+#include <gt_processdata.h>
+
+#include <QString>
+
+namespace gtpy
+{
+
+/**
+ * @brief Parsed task specification in `taskId` or `groupId/taskId` form.
+ */
+struct TaskSpec
+{
+    QString groupId;
+    QString taskId;
+    bool hasExplicitGroup{false};
+};
+
+/**
+ * @brief Parse a task specification string.
+ *
+ * @param spec Task identifier in `taskId` or `groupId/taskId` form.
+ * @return Parsed task specification parts.
+ */
+TaskSpec parseTaskSpec(const QString& spec);
+
+/**
+ * @brief Gets the task from the process
+ *
+ * @param data The processdata owning the task.
+ * @param taskSpec Task spec in `taskId` or `groupId/taskId` form.
+ */
+GtTask* getTask(GtProcessData* data, TaskSpec spec);
+
+} // namespace gtpy
+
+#endif // GTPY_TASKAPI_H


### PR DESCRIPTION
I added a small task api, to provide a uniform task access.

This PR fixed in particular:
 - `findGtTask` inside python tasks
 - `runProcess` from the interactive console

Note: task groups might not be intialized yet. if so, the intializitation is executed in the main thread.

Closes #639